### PR TITLE
Fix query string truncation in nginx configuration

### DIFF
--- a/.devilbox/etc/nginx-mainline/02-vhost-mass.conf
+++ b/.devilbox/etc/nginx-mainline/02-vhost-mass.conf
@@ -28,7 +28,7 @@ server {
 
 	# Front-controller pattern as recommended by the nginx docs
 	location / {
-		try_files $uri $uri/ /index.php;
+		try_files $uri $uri/ /index.php$is_args$args;
 	}
 
 	# PHP FPM

--- a/.devilbox/etc/nginx-stable/02-vhost-mass.conf
+++ b/.devilbox/etc/nginx-stable/02-vhost-mass.conf
@@ -28,7 +28,7 @@ server {
 
 	# Front-controller pattern as recommended by the nginx docs
 	location / {
-		try_files $uri $uri/ /index.php;
+		try_files $uri $uri/ /index.php$is_args$args;
 	}
 
 	# PHP FPM


### PR DESCRIPTION
Fixes:

- Query string parameters were truncated during request when `try_files` directive applied.

Example:

When: Request `/any/uri?foo=bar`

Should see:

```php
$_GET = ['foo' => 'bar'];
```
PHP sees:

```php
$_GET = [];
```