### PR TITLE
DVL-013 removing invalid option from quick start docker-composer remo…

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -90,7 +90,7 @@ $ docker-compose stop
 
 # Remove the stopped container (IMPORTANT!)
 # After the removal it will be re-created during next run
-$ docker-compose rm -rf
+$ docker-compose rm -f
 ```
 
 #### 3.2 Services


### PR DESCRIPTION
…val in the docs

#### Short description

The original command meant that the help text showed up because -r is not a valid option. 

#### Tasks done

* [ ] Updated `$DEVILBOX_DATE` in [config.php](https://github.com/cytopia/devilbox/blob/master/.devilbox/www/config.php#L17)
