### PR TITLE
Ignore `docker-compose.override.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 /data/*
 /backups/*
 
+# Ignore compose override file
+docker-compose.override.yml
+
 # Ignore custom HTTPD configs
 /cfg/apache-2.2/*.conf
 /cfg/apache-2.4/*.conf


### PR DESCRIPTION
# Ignore `docker-compose.override.yml`

#### Short description

As per [Docker Compose documentation](https://docs.docker.com/compose/extends) it's possible to use a `docker-compose.override.yml` file to override/extend configurations of a `docker-compose.yml`.

This is an excellent way for one to perform own/local tweaks and overrides without changing/impacting project files. This PR updates `.gitignore` adding a line for the override file.

By permitting this override file, cleaner local/tailored solutions can be applied to issues like #32 and #90. An example of a solution resorting to an override file can be seen [here](https://github.com/cytopia/devilbox/issues/90#issuecomment-382701379).