### PR TITLE
disable mysql query log by default

### DIFF
--- a/docs/configuration-files/env-file.rst
+++ b/docs/configuration-files/env-file.rst
@@ -1337,7 +1337,7 @@ As the Devilbox is intended to be used for development, this feature is turned o
 +-------------------------+-------------------+---------------------+
 | Name                    | Allowed values    | Default value       |
 +=========================+===================+=====================+
-| ``MYSQL_GENERAL_LOG``   | ``0`` or ``1``    | ``1``               |
+| ``MYSQL_GENERAL_LOG``   | ``0`` or ``1``    | ``0``               |
 +-------------------------+-------------------+---------------------+
 
 **MySQL documentation:**

--- a/env-example
+++ b/env-example
@@ -453,7 +453,7 @@ MYSQL_ROOT_PASSWORD=
 ###
 ### Custom MySQL Runtime Settings
 ###
-MYSQL_GENERAL_LOG=1
+MYSQL_GENERAL_LOG=0
 
 ###
 ### Expose MySQL Port to Host


### PR DESCRIPTION
I've migrated a few things over to devilbox, pretty happy with it, but there was one surprise.
I'm using MySQL 5.7, didn't test other databases. After moving a few things I've noticed a rather big file `devilbox/log/mysql-5.7/query.log`.

While I do like that devilbox offers the option to enable a query log, I don't think it should be enable by default. I'll delete a 80G file now 😄 