### PR TITLE
Fix #242 - Prevent auto-starts on Windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
   # ------------------------------------------------------------
   bind:
     image: cytopia/bind:0.15
-    restart: always
     ports:
       # [local-machine:]local-port:docker-port
       - "${LOCAL_LISTEN_ADDR}${HOST_PORT_BIND:-1053}:53/tcp"
@@ -95,7 +94,6 @@ services:
   # ------------------------------------------------------------
   php:
     image: devilbox/php-fpm:${PHP_SERVER:-7.0}-work
-    restart: always
 
     ##
     ## All .env variables
@@ -206,7 +204,6 @@ services:
   # ------------------------------------------------------------
   httpd:
     image: devilbox/${HTTPD_SERVER:-nginx-stable}:0.17
-    restart: always
 
     environment:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
   # ------------------------------------------------------------
   bind:
     image: cytopia/bind:0.15
+    restart: always
     ports:
       # [local-machine:]local-port:docker-port
       - "${LOCAL_LISTEN_ADDR}${HOST_PORT_BIND:-1053}:53/tcp"


### PR DESCRIPTION
Remove `restart: always` to prevent containers to be started during Windows system start


Usage:
```bash
docker-compose stop
docker-compose rm -f
git checkout fix-win-autostart
```