### PR TITLE
Fix PHP 7.2 deprecated function: create_function()

### DIFF
--- a/.devilbox/www/include/vendor/Mail/mimeDecode.php
+++ b/.devilbox/www/include/vendor/Mail/mimeDecode.php
@@ -832,10 +832,16 @@ class Mail_mimeDecode extends PEAR
         // Remove soft line breaks
         $input = preg_replace("/=\r?\n/", '', $input);
 
-        // Replace encoded characters
-		 
-        $cb = create_function('$matches',  ' return chr(hexdec($matches[0]));');
-         
+		// cytopia edit
+		if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+			$cb = function($matches) {
+				return chr(hexdec($matches[0]));
+			};
+		} else {
+			// Replace encoded characters
+			$cb = create_function('$matches',  ' return chr(hexdec($matches[0]));');
+		}
+
         $input = preg_replace_callback( '/=([a-f0-9]{2})/i', $cb, $input);
 
         return $input;


### PR DESCRIPTION
# PHP 7.2 deprecated function: create_function()

#### Description
Ensure PHP >= 7.2 uses lambda instead of `create_function()`.
