### PR TITLE
Fixed small links mixup

### DIFF
--- a/docs/_includes/links/tools.rst
+++ b/docs/_includes/links/tools.rst
@@ -257,13 +257,13 @@
 
 .. |ext_lnk_tool_phpmyadmin| raw:: html
 
-   <a target="_blank" href="https://github.com/sasanrose/phpredmin">
+   <a target="_blank" href="https://www.phpmyadmin.net">
      phpRedMin <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 
 .. |ext_lnk_tool_phpredmin| raw:: html
 
-   <a target="_blank" href="https://www.phpmyadmin.net">
+   <a target="_blank" href="https://github.com/sasanrose/phpredmin">
      phpMyAdmin <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 


### PR DESCRIPTION
Phpmyadmin and Phpredmin links were in the incorrect place. Just switched places.

<!-- Add a name to your PR below -->
# FEATURE_NAME


#### DESCRIPTION

<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

