### PR TITLE
Release v1.0.0: Auto DNS (breaking changes)

### DIFF
--- a/docker-compose.override.yml-example
+++ b/docker-compose.override.yml-example
@@ -18,6 +18,5 @@ services:
         ipv4_address: 172.16.238.200
     # (Optional) For ease of use always automatically start these:
     depends_on:
-      - bind
       - php
       - httpd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,22 +25,20 @@
 version: '2.1'
 
 
-################################################################################
+###################################################################################################
 # SERVICES
-################################################################################
+###################################################################################################
 services:
 
   # ------------------------------------------------------------
-  # Bind (DNS Server)
+  # Internal DNS for PHP container (Required)
   # ------------------------------------------------------------
-  bind:
+  # This container must always run and is only intended for the
+  # PHP-FPM container so that they are able to resolve custom
+  # DNS and direct all requests to the Devilbox http server.
+  intdns:
     image: cytopia/bind:0.15
     restart: always
-    ports:
-      # [local-machine:]local-port:docker-port
-      - "${LOCAL_LISTEN_ADDR}${HOST_PORT_BIND:-1053}:53/tcp"
-      - "${LOCAL_LISTEN_ADDR}${HOST_PORT_BIND:-1053}:53/udp"
-
     environment:
       ##
       ## Debug?
@@ -48,9 +46,16 @@ services:
       - DEBUG_ENTRYPOINT=${DEBUG_COMPOSE_ENTRYPOINT}
 
       ##
-      ## Bind wildcard/host settings
+      ## ---- THIS LINE MAKES THE MAGIC HAPPEN ----
       ##
-      - WILDCARD_DNS=${TLD_SUFFIX:-loc}=127.0.0.1
+      ## Ensure all wildcard DNS requests from the PHP-Container
+      ## resolve to the Devilbox http server
+      ##
+      - WILDCARD_DNS=${TLD_SUFFIX:-loc}=172.16.238.11
+
+      ##
+      ## Add extra hosts to be resolvable
+      ##
       - EXTRA_HOSTS=${EXTRA_HOSTS}
 
       ##
@@ -85,10 +90,80 @@ services:
       docker.for.lin.host.internal: 172.16.238.1
       docker.for.lin.localhost: 172.16.238.1
 
-    hostname: bind
+    hostname: intdns
     networks:
       app_net:
         ipv4_address: 172.16.238.100
+
+
+  # ------------------------------------------------------------
+  # AutoDNS: DNS for your host operating system (Optional)
+  # ------------------------------------------------------------
+  # This container is intended to provide Auto-DNS for your
+  # host operating system, if you wish so.
+  autodns:
+    image: cytopia/bind:0.15
+    ports:
+      # [local-machine:]local-port:docker-port
+      - "${LOCAL_LISTEN_ADDR}${HOST_PORT_BIND:-1053}:53/tcp"
+      - "${LOCAL_LISTEN_ADDR}${HOST_PORT_BIND:-1053}:53/udp"
+
+    environment:
+      ##
+      ## Debug?
+      ##
+      - DEBUG_ENTRYPOINT=${DEBUG_COMPOSE_ENTRYPOINT}
+
+      ##
+      ## ---- THIS LINE MAKES THE MAGIC HAPPEN ----
+      ##
+      ## This line assigns the IP address on which the Devilbox is available
+      ## to your host operating system.
+      ## Bind wildcard/host settings
+      ##
+      - WILDCARD_DNS=${TLD_SUFFIX:-loc}=${AUTODNS_HOST_ADDRESS}
+
+      ##
+      ## Add extra hosts to be resolvable
+      ##
+      - EXTRA_HOSTS=${EXTRA_HOSTS}
+
+      ##
+      ## Forwarding
+      ##
+      - DNS_FORWARDER=${BIND_DNS_RESOLVER:-8.8.8.8,8.8.4.4}
+
+      ##
+      ## Security
+      ##
+      - DNSSEC_VALIDATE=${BIND_DNSSEC_VALIDATE:-no}
+
+      ##
+      ## Time settings
+      ##
+      - TTL_TIME=${BIND_TTL_TIME}
+      - REFRESH_TIME=${BIND_REFRESH_TIME}
+      - RETRY_TIME=${BIND_RETRY_TIME}
+      - EXPIRY_TIME=${BIND_EXPIRY_TIME}
+      - MAX_CACHE_TIME=${BIND_MAX_CACHE_TIME}
+
+      ##
+      ## Query log
+      ##
+      - DOCKER_LOGS=${BIND_LOG_DNS_QUERIES}
+
+    dns:
+      - 127.0.0.1
+
+    # MacOS and Windows have this by default, this hack also allows it for Linux
+    extra_hosts:
+      docker.for.lin.host.internal: 172.16.238.1
+      docker.for.lin.localhost: 172.16.238.1
+
+    hostname: autodns
+    networks:
+      app_net:
+        ipv4_address: 172.16.238.101
 
 
   # ------------------------------------------------------------
@@ -199,7 +274,7 @@ services:
       - ${DEVILBOX_PATH}/ca:/ca:rw${MOUNT_OPTIONS}
 
     depends_on:
-      - bind
+      - intdns
 
 
   # ------------------------------------------------------------
@@ -291,7 +366,6 @@ services:
       - ${DEVILBOX_PATH}/ca:/ca:rw${MOUNT_OPTIONS}
 
     depends_on:
-      - bind
       - php
 
 
@@ -355,7 +429,6 @@ services:
       - ${HOST_PATH_MYSQL_DATADIR}/${MYSQL_SERVER}:/var/lib/mysql:rw${MOUNT_OPTIONS}
 
     depends_on:
-      - bind
       - php
       - httpd
 
@@ -392,7 +465,6 @@ services:
       - ${HOST_PATH_PGSQL_DATADIR}/${PGSQL_SERVER}:/var/lib/postgresql/data/pgdata:rw${MOUNT_OPTIONS}
 
     depends_on:
-      - bind
       - php
       - httpd
 
@@ -425,7 +497,6 @@ services:
       - ${DEVILBOX_PATH}/log/redis-${REDIS_SERVER}:/var/log/redis:rw${MOUNT_OPTIONS}
 
     depends_on:
-      - bind
       - php
       - httpd
 
@@ -453,7 +524,6 @@ services:
       - ${DEVILBOX_PATH}/log/memcd-${MEMCD_SERVER}:/var/log/memcd:rw${MOUNT_OPTIONS}
 
     depends_on:
-      - bind
       - php
       - httpd
 
@@ -481,14 +551,13 @@ services:
       - ${HOST_PATH_MONGO_DATADIR}/${MONGO_SERVER}:/data/db:rw${MOUNT_OPTIONS}
 
     depends_on:
-      - bind
       - php
       - httpd
 
 
-################################################################################
+###################################################################################################
 # NETWORK
-################################################################################
+###################################################################################################
 networks:
   app_net:
     driver: bridge

--- a/env-example
+++ b/env-example
@@ -628,7 +628,7 @@ HOST_PORT_MONGO=27017
 
 ################################################################################
 ###
-### 10. Bind Docker Settings
+### 10. AutoDNS Settings
 ###
 ################################################################################
 
@@ -636,6 +636,19 @@ HOST_PORT_MONGO=27017
 ### Expose Bind Port to Host
 ###
 HOST_PORT_BIND=1053
+
+###
+### The IP address to which direct all DNS resolutions.
+###
+### This settings really depend on where you want to access your Devilbox projects
+### from your host computer's browser.
+###
+### If you access the Devilbox on 127.0.0.1, then set this to 127.0.0.1
+### If however you're running Docker Toolbox and the Devilbox IP address is something
+### like 192.168.99.100, then set it to 192.168.99.100. (Note, this is only an example)
+### In case of Docker Toolbox, you will have to find out the IP address first.
+###
+AUTODNS_HOST_ADDRESS=127.0.0.1
 
 ###
 ### Add comma separated DNS server from which you want to receive DNS


### PR DESCRIPTION
# AutoDNS

### DESCRIPTION

This PR splits the currently called DNS container `bind` into two separate containers: `intdns` and `autodns`

* Refs #248

#### intdns (required to run)

The `intdns` container will only be responsible to handle DNS queries internally for the PHP container, directing all queries to the Devilbox HTTP server. This container must always run in order to be able to resolve virtual hosts from within the PHP container (e.g. `curl https://project1.loc`).

#### autodns (optional)

The `autodns` container will be responsible to take care about the DNS for your host operating system. Previously all queries resolved to `127.0.0.1` by default. This however did not work for legacy solutions such as Docker Toolbox. In order to mitigate this issue, this container has been made configurable to specify the IP address where the Devilbox is serving the virtual hosts. For native solutions this is set to `127.0.0.1` by default. If you're using Docker Toolbox, you can set this value to `192.168.99.100` via the `.env` file for instance:

```bash
###
### The IP address to which direct all DNS resolutions.
###
### This settings really depend on where you want to access your Devilbox projects
### from your host computer's browser.
###
### If you access the Devilbox on 127.0.0.1, then set this to 127.0.0.1
### If however you're running Docker Toolbox and the Devilbox IP address is something
### like 192.168.99.100, then set it to 192.168.99.100. (Note, this is only an example)
### In case of Docker Toolbox, you will have to find out the IP address first.
###
AUTODNS_HOST_ADDRESS=127.0.0.1
```


### State

This PR is currently WIP, but already usable if you want to try it out. There are however still a few things that need to be addressed before this can be released.

### Todo

* Update documentation (especially how to setup various frameworks and change address of MySQL/PgSQL/etc to their respective hostnames)
* Update PHP-FPM container and remove port-forwards and make them even slimmer (port-forwards of services to `127.0.0.1` into the PHP container will not be required any more)


### Important

Once you're using this feature, you should not rely on any services being bound to `127.0.0.1` on the PHP container anymore. You should from now on either:

1. stick to their hostnames
2. or use custom environment variables to tell PHP where other services can be reached: https://devilbox.readthedocs.io/en/latest/configuration-files/env-file.html#custom-variables

The second option is anyhow much better in case you decide for example to use a database outside the Devilbox docker environment. Then you will only have to adjust the `.env` variable and you're all set. 