### PR TITLE
Use HTTP/2 as default for all SSL connections

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -14,7 +14,7 @@ putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
 $DEVILBOX_VERSION = 'v0.15';
-$DEVILBOX_DATE = '2019-01-02';
+$DEVILBOX_DATE = '2019-01-06';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ The Devilbox has everything setup for you. The only thing you will have to insta
 <table>
 <tbody>
   <tr>
+    <td width="220" style="width:220px;">:star: HTTP/2 support</td>
+    <td>All HTTPS connections will offer <a href="https://en.wikipedia.org/wiki/HTTP/2">HTTP/2</a> as the default protocol, except for Apache 2.2 which does not support it.</td>
+  </tr>
+  <tr>
     <td width="220" style="width:220px;">:star: Auto virtual hosts</td>
     <td>New virtual hosts are created automatically and instantly whenever you add a project directory. This is done internally via <a href="https://travis-ci.org/devilbox/vhost-gen">vhost-gen</a> and <a href="https://github.com/devilbox/watcherd">watcherd</a>.</td>
   </tr>
@@ -423,7 +427,7 @@ The Devilbox has everything setup for you. The only thing you will have to insta
   </tr>
   <tr>
     <td>:star: Custom domains</td>
-    <td>Choose whatever development domain you desire: <code>*.loc</code>, <code>*.local</code>, <code>*.dev</code> or use real domains as well: <code>*.example.com</code></td>
+    <td>Choose whatever development domain you desire: <code>*.loc</code>, <code>*.dev</code> or use real domains as well: <code>*.example.com</code></td>
   </tr>
   <tr>
     <td>:star: Auto DNS</td>

--- a/cfg/vhost-gen/apache24.yml-example-rproxy
+++ b/cfg/vhost-gen/apache24.yml-example-rproxy
@@ -40,7 +40,8 @@
 ###
 vhost: |
   <VirtualHost __DEFAULT_VHOST__:__PORT__>
-      ServerName   __VHOST_NAME__
+      ServerName __VHOST_NAME__
+      Protocols  __HTTP_PROTO__
 
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"

--- a/cfg/vhost-gen/apache24.yml-example-vhost
+++ b/cfg/vhost-gen/apache24.yml-example-vhost
@@ -46,7 +46,8 @@
 ###
 vhost: |
   <VirtualHost __DEFAULT_VHOST__:__PORT__>
-      ServerName   __VHOST_NAME__
+      ServerName __VHOST_NAME__
+      Protocols  __HTTP_PROTO__
 
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"

--- a/cfg/vhost-gen/nginx.yml-example-rproxy
+++ b/cfg/vhost-gen/nginx.yml-example-rproxy
@@ -40,7 +40,7 @@
 ###
 vhost: |
   server {
-      listen       __PORT____DEFAULT_VHOST__;
+      listen       __PORT____HTTP_PROTO____DEFAULT_VHOST__;
       server_name  __VHOST_NAME__;
 
       access_log   "__ACCESS_LOG__" combined;

--- a/cfg/vhost-gen/nginx.yml-example-vhost
+++ b/cfg/vhost-gen/nginx.yml-example-vhost
@@ -46,7 +46,7 @@
 ###
 vhost: |
   server {
-      listen       __PORT____DEFAULT_VHOST__;
+      listen       __PORT____HTTP_PROTO____DEFAULT_VHOST__;
       server_name  __VHOST_NAME__;
 
       access_log   "__ACCESS_LOG__" combined;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:0.25
+    image: devilbox/${HTTPD_SERVER}:0.26
     hostname: httpd
 
     environment:


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# HTTP/2 as default for all SSL connections


#### DESCRIPTION

This PR makes HTTP/2 the default for all HTTPS connections.

1. It will work for Nginx stable/mainline and Apache 2.4.
2. Apache 2.2 is too old and does not support HTTP/2.

* Fixes: #431

#### IMPORTANT

This PR updates the vhost-gen templates in `cfg/vhost-gen/*.yml-example-*`. So if you have currently applied custom per project or global vhost-gen templates, ensure to update them accordingly from the given examples.

#### FURTHER INFORMATION

Other involved PR's:

* vhost-gen: https://github.com/devilbox/vhost-gen/pull/33
* Apache 2.4: https://github.com/devilbox/docker-apache-2.4/pull/21
* Nginx stable: https://github.com/devilbox/docker-nginx-stable/pull/21
* Nginx mainline: https://github.com/devilbox/docker-nginx-mainline/pull/22

<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

