### PR TITLE
Use new HTTP container that properly read global vhost-gen config

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -14,7 +14,7 @@ putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
 $DEVILBOX_VERSION = 'v0.15';
-$DEVILBOX_DATE = '2019-01-06';
+$DEVILBOX_DATE = '2019-01-07';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:0.26
+    image: devilbox/${HTTPD_SERVER}:0.27
     hostname: httpd
 
     environment:


### PR DESCRIPTION
# Use new HTTP container that properly read global vhost-gen config



#### DESCRIPTION

This PR fixes an Issue with HTTP container other than Apache 2.2. Now every HTTP container reads his own vhost-gen config instead of the Apache 2.2 one.

* Fixes: https://github.com/cytopia/devilbox/issues/463

<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

#### HTTP changes

* https://github.com/devilbox/docker-nginx-mainline/pull/23
* https://github.com/devilbox/docker-nginx-stable/pull/22
* https://github.com/devilbox/docker-apache-2.4/pull/22