### PR TITLE
Fix documentation links

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,7 +55,7 @@ else
 	bash -c 'curl -Ss -o linkcheck -z linkcheck https://raw.githubusercontent.com/cytopia/linkcheck/master/linkcheck 2>/dev/null'
 endif
 	chmod +x linkcheck
-	./linkcheck -k -r 60 -t 30 -e rst _includes/
+	./linkcheck -l -k -r 60 -t 30 -e rst _includes/
 
 build:
 	sphinx-build -a -E -n -j auto -q -W . _build/html

--- a/docs/_includes/links/examples.rst
+++ b/docs/_includes/links/examples.rst
@@ -42,7 +42,7 @@
 
 .. |ext_lnk_example_phalcon_documentation| raw:: html
 
-   <a target="_blank" href="https://docs.phalconphp.com/en/3.2/devtools-usage">
+   <a target="_blank" href="https://docs.phalconphp.com/latest/en/devtools-usage">
      Official Phalcon Documentation  <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 

--- a/docs/_includes/links/tools.rst
+++ b/docs/_includes/links/tools.rst
@@ -35,7 +35,7 @@
 
 .. |ext_lnk_tool_dep| raw:: html
 
-   <a target="_blank" href="https://deployer.org/">
+   <a target="_blank" href="https://deployer.org">
      Deployer <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# Fix documentation links


#### DESCRIPTION

A simple fix on links provided in the documentation. Also ensures that redirects are not treated as a CI error anymore if the last redirect resolved in `200`.

For more details see here: https://github.com/cytopia/linkcheck
<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

