### PR TITLE
Fix example command @ customizing vhost template

### DIFF
--- a/docs/vhost-gen/customize-specific-virtual-host.rst
+++ b/docs/vhost-gen/customize-specific-virtual-host.rst
@@ -119,7 +119,7 @@ Then you can copy the templates.
 
 .. code-block:: bash
 
-   host> cp cfg/vhost-gen/*.yml-example ./data/www/project-1/.devilbox
+   host> cp cfg/vhost-gen/*.yml-example-* ./data/www/project-1/.devilbox
 
 .. note::
    You actually only need to copy the template of your chosen webserver (either Apache 2.2,


### PR DESCRIPTION
<!-- Add a name to your PR below -->
Fix example command @ customizing vhost template [docs](https://devilbox.readthedocs.io/en/latest/vhost-gen/customize-specific-virtual-host.html#copy-webserver-template-to-project-template-directory) 

### Goal
<!-- What is the goal of this Pull request -->
<!-- What do you want to achieve? -->


### DESCRIPTION

I've followed the docs for creating custom vhost template but unfortunately the example command didn't worked because the file name does not match