### PR TITLE
Set client_max_body_size to 0 for Nginx to be in line with Apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,11 +462,15 @@ The Devilbox has everything setup for you. The only thing you will have to insta
 <table>
 <tbody>
   <tr>
-    <td width="220" style="width:220px;">:star: HTTP/2 support</td>
+    <td width="220" style="width:220px;">:star: HTTPS support</td>
+    <td>HTTPS is available by default for all projects and the bundled Intranet.</td>
+  </tr>
+  <tr>
+    <td>:star: HTTP/2 support</td>
     <td>All HTTPS connections will offer <a href="https://en.wikipedia.org/wiki/HTTP/2">HTTP/2</a> as the default protocol, except for Apache 2.2 which does not support it.</td>
   </tr>
   <tr>
-    <td width="220" style="width:220px;">:star: Auto virtual hosts</td>
+    <td>:star: Auto virtual hosts</td>
     <td>New virtual hosts are created automatically and instantly whenever you add a project directory. This is done internally via <a href="https://travis-ci.org/devilbox/vhost-gen">vhost-gen</a> and <a href="https://github.com/devilbox/watcherd">watcherd</a>.</td>
   </tr>
   <tr>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:0.28
+    image: devilbox/${HTTPD_SERVER}:0.29
     hostname: httpd
 
     environment:


### PR DESCRIPTION
# Set client_max_body_size to 0 for Nginx to be in line with Apache

<!-- Add a name to your PR below -->
# FEATURE_NAME

### Goal

Ensure that Nginx and Apache default configurations are as equals as possible
<!-- What is the goal of this Pull request -->
<!-- What do you want to achieve? -->


### DESCRIPTION

* Set `client_max_body_size` to `0` for Nginx
* Set `worker_processes` to `auto` for Nginx
* Add `Via` header for Nginx and Apache 2.4
* Fixes: #356
* Refs: #393

<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

