### PR TITLE
Feature: docker-sync

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,18 @@
+version: '2.1'
+
+services:
+  php:
+    volumes:
+      - devilbox-intranet-sync:/var/www/default:nocopy
+      - devilbox-data-www-sync:/shared/httpd:nocopy
+  httpd:
+    volumes:
+      - devilbox-intranet-sync:/var/www/default:nocopy
+      - devilbox-data-www-sync:/shared/httpd:nocopy
+
+volumes:
+  # docker-sync managed volumes
+  devilbox-intranet-sync:
+    external: true
+  devilbox-data-www-sync:
+    external: true

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,63 @@
+version: '2'
+
+
+options:
+  # The path to devilbox docker-compose.yml file
+  compose-file-path: 'docker-compose.yml'
+
+  # The path to your custom docker-compose-dev.yml file
+  compose-dev-file-path: 'docker-compose-dev.yml'
+
+
+syncs:
+  # ------------------------------------------------------------
+  # Devilbox Intranet
+  # ------------------------------------------------------------
+  devilbox-intranet-sync:
+    # which folder to watch / sync from - you can use tilde (~), it will get expanded.
+    # Be aware that the trailing slash makes a difference
+    # if you add them, only the inner parts of the folder gets synced, otherwise the parent folder
+    # will be synced as top-level folder
+    src: '${DEVILBOX_PATH}/.devilbox/www/'
+
+    # this does not user groupmap but rather configures the server to map
+    # optional: usually if you map users you want to set the user id of your application
+    # container here
+    sync_userid: '${NEW_UID}'
+
+    # OS aware sync strategy, default to:
+    # * native_osx under MacOS (native)
+    # * unison under MacOS (docker-machine)
+    # * native docker volume under linux
+    #sync_strategy: 'unison'
+
+    # optional, a list of excludes. These patterns will not be synced see:
+    # http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#ignore
+    # for the possible syntax and see sync_excludes_type below
+    sync_excludes: ['.gitignore', '.git/', '.idea/', '.vscode/']
+
+  # ------------------------------------------------------------
+  # Devilbox Projects
+  # ------------------------------------------------------------
+  devilbox-data-www-sync:
+    # which folder to watch / sync from - you can use tilde (~), it will get expanded.
+    # Be aware that the trailing slash makes a difference
+    # if you add them, only the inner parts of the folder gets synced, otherwise the parent folder
+    # will be synced as top-level folder
+    src: '${HOST_PATH_HTTPD_DATADIR}/'
+
+    # this does not user groupmap but rather configures the server to map
+    # optional: usually if you map users you want to set the user id of your application
+    # container here
+    sync_userid: '${NEW_UID}'
+
+    # OS aware sync strategy, default to:
+    # * native_osx under MacOS (native)
+    # * unison under MacOS (docker-machine)
+    # * native docker volume under linux
+    #sync_strategy: 'unison'
+
+    # optional, a list of excludes. These patterns will not be synced see:
+    # http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#ignore
+    # for the possible syntax and see sync_excludes_type below
+    sync_excludes: ['.gitignore', '.git/', '.idea/', '.vscode/']


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# docker-sync

## GOAL
Run the Devilbox at acceptable performance on MacOS and Windows. (Ignore this PR for Linux)

## DESCRIPTION
This PR adds [docker-sync](https://github.com/EugenMayer/docker-sync) support to the Devilbox.

* Refs: #105 

## How to use it:
* Docker sync docs: https://docker-sync.readthedocs.io/en/latest/index.html#

### 1. Requirements
#### 1.1 MacOS
```bash
# Install docker-sync
sudo gem install docker-sync

# Install additional requirements
brew install unison
brew install eugenmayer/dockersync/unox
```
#### 1.2 Windows
https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html

### 2. Start
Stop and clean your stack first
```bash
# Clean
docker-compose stop
docker-compose rm
```
Start docker-sync (**and wait until it finishes successfully**):
```bash
docker-sync start
```
Start the Devilbox as usual
```bash
docker-compose up php httpd bind
```

### 3. Stop
1. Ctrl+c to stop the Devilbox or `docker-compose stop`
2. Clean state: `docker-compose rm`
3. Stop docker-sync: `docker-sync stop`