### PR TITLE
Very small typo fix

### DIFF
--- a/docs/examples/setup-wordpress.rst
+++ b/docs/examples/setup-wordpress.rst
@@ -9,7 +9,7 @@ Setup Wordpress
 
 This example will use ``git`` to install Wordpress from within the Devilbox PHP container.
 
-After completing the below listed steps, you will have a working Laravel setup ready to be
+After completing the below listed steps, you will have a working Wordpress setup ready to be
 served via http and https.
 
 .. seealso:: |ext_lnk_example_wordpress_documentation|


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# typo_fix

I just fixed a small typo in the "setup wordpress" part of the docs.

