### PR TITLE
Add blog post reference to documentation

### DIFF
--- a/docs/_includes/links/blogs.rst
+++ b/docs/_includes/links/blogs.rst
@@ -1,3 +1,9 @@
+.. |ext_lnk_blog_openstream| raw:: html
+
+   <a target="_blank" href="https://www.openstream.ch/developer-blog/devilbox/">
+     Docker LAMP Stack for WordPress and Magento <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
+   </a>
+
 .. |ext_lnk_blog_deliciousbrains| raw:: html
 
    <a target="_blank" href="https://deliciousbrains.com/devilbox-local-wordpress-development-docker/">

--- a/docs/support/blogs-videos-and-use-cases.rst
+++ b/docs/support/blogs-videos-and-use-cases.rst
@@ -46,6 +46,8 @@ The following shows a list of blogs that give a nice and objective introduction 
 +---------------------------------+----------+
 | |ext_lnk_blog_moritzkanzler|    | German   |
 +---------------------------------+----------+
+| |ext_lnk_blog_openstream|       | English  |
++---------------------------------+----------+
 
 
 Use-cases


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# New blog post

### Goal
Add blog post [Docker LAMP Stack for WordPress and Magento](https://www.openstream.ch/developer-blog/devilbox/) reference to documentation.

### DESCRIPTION

Little write up from the perspective of a WordPress and Magento developer.