### PR TITLE
Fix CI tests for mail volume

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -14,7 +14,7 @@ putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
 $DEVILBOX_VERSION = 'v1.0.1';
-$DEVILBOX_DATE = '2019-04-12';
+$DEVILBOX_DATE = '2019-04-20';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/.tests/Makefile
+++ b/.tests/Makefile
@@ -415,7 +415,7 @@ _clean-round:
 	$(eval HTTPD_SERVER := $(shell grep -E '^HTTPD_SERVER' $(DEVILBOX_PATH)/.env | sed 's/.*=//g'))
 	$(eval PHP_SERVER   := $(shell grep -E '^PHP_SERVER' $(DEVILBOX_PATH)/.env | sed 's/.*=//g'))
 
-	@> $(DEVILBOX_PATH)/mail/devilbox
+	@cd $(DEVILBOX_PATH) && docker-compose exec php truncate -s0 /var/mail/devilbox
 
 	@> $(DEVILBOX_PATH)/log/php-fpm-$(PHP_SERVER)/php-fpm.access
 	@> $(DEVILBOX_PATH)/log/php-fpm-$(PHP_SERVER)/php-fpm.error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ major versions.
 - Fixed various typos in documentation
 
 
+## Unreleased
+
+- Fix CI tests: They still expected a mounted mail directory instead of a Docker volume
+
+
 ## Bugfix Release v1.0.1 (2019-03-24)
 
 This is a bugfix release and everybody is encouraged to upgrade to this tag as soon as possible.


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# Fix CI tests for mail volume

### Goal

* Ensure CI tests adhere to new Docker volume setup
<!-- What is the goal of this Pull request -->
<!-- What do you want to achieve? -->


### DESCRIPTION

The email directory was still treated as a mounted Volume within the CI tests. Emptying its content has now been adjusted to work with the new setup.
<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

