### PR TITLE
Update release tag on update docs

### DIFF
--- a/docs/maintenance/update-the-devilbox.rst
+++ b/docs/maintenance/update-the-devilbox.rst
@@ -58,7 +58,7 @@ If you want to checkout a specific release tag (such as ``0.12.1``), do a ``git 
    host> cd path/to/devilbox
    # Ensure you have latest from remote
    host> git fetch
-   host> git checkout 0.12.1
+   host> git checkout v1.0.1
 
 
 


### PR DESCRIPTION
**Goal:** Updates the release/version tag on the Devilbox update documentation.

(Sorry I deviated from the PR template, but the patch was so simple I thought it was overkill to format description exactly as such.)