### PR TITLE
Re-enable Adminer tests for PHP 7.3

### DIFF
--- a/.tests/intra-tests/vendor-adminer.sh
+++ b/.tests/intra-tests/vendor-adminer.sh
@@ -5,7 +5,7 @@ set -u
 set -o pipefail
 
 
-DISABLED_VERSIONS_MONGO=("7.3")
+DISABLED_VERSIONS_MONGO=("")
 
 #
 # NOTE: Parsing curl to tac to circumnvent "failed writing body"


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# Re-enable Adminer tests for PHP 7.3

### Goal

Have CI tests equal across all PHP versions.
<!-- What is the goal of this Pull request -->
<!-- What do you want to achieve? -->


### DESCRIPTION

This PR re-enabled the Devilbox Intranet CI tests for the current Adminer version for MongoDB on PHP 7.3.
<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

