### PR TITLE
Warn about colon when setting local listen address

### DIFF
--- a/docs/intermediate/setup-auto-dns.rst
+++ b/docs/intermediate/setup-auto-dns.rst
@@ -33,7 +33,7 @@ on ``0.0.0.0``. Additionally the DNS server port must be set to ``53`` (it is no
 Prerequisites
 -------------
 
-First ensure that :ref:`env_local_listen_addr` is either empty or listening on ``127.0.0.1``.
+First ensure that :ref:`env_local_listen_addr` is either empty or listening on ``127.0.0.1``. Also note that the address *must* have a colon (``:``) appended, this is not added automatically and is needed to conjoin the ip address and ports correctly.
 
 .. code-block:: bash
    :caption: .env


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# Update intermediate docs for configuring auto dns

### Goal
<!-- What is the goal of this Pull request -->
Fix an inconsistency in the .env example and the docs.

<!-- What do you want to achieve? -->


### DESCRIPTION

<!-- Enter a short description here -->

Update the docs to warn that a colon must be present when attempting to explicitly set the local listen address. Omitting this will lead to errors about ports being invalid.

<!-- Link to issues in case it fixes an issue -->

