### PR TITLE
Updates end-of-line for batch file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -70,7 +70,12 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
-[{shell.bat,shell.sh,update-docker.sh}]
+[{shell.sh,update-docker.sh}]
+indent_style = tab
+indent_size = 4
+
+[shell.bat]
+end_of_line = crlf
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
# Batch file line-endings.

### Goal
`.editorconfig` should specify `crlf` line-endings for `shell.bat`

### DESCRIPTION
Although `shell.bat` is currently a one-liner, it might be modified by a user. And using *nix' `lf` line endings in Windows batch files can lead to [unexpected results](https://stackoverflow.com/questions/232651/why-the-system-cannot-find-the-batch-label-specified-is-thrown-even-if-label-e).


