### PR TITLE
Fix reverse proxy docs

### DIFF
--- a/docs/examples/setup-reverse-proxy-sphinx-docs.rst
+++ b/docs/examples/setup-reverse-proxy-sphinx-docs.rst
@@ -390,7 +390,7 @@ host operating systems ``/etc/hosts`` file (or ``C:\Windows\System32\drivers\etc
 .. code-block:: bash
    :caption: /etc/hosts
 
-   127.0.0.1 my-node.loc
+   127.0.0.1 my-sphinx.loc
 
 .. seealso::
 

--- a/docs/reverse-proxy/reverse-proxy-for-custom-docker.rst
+++ b/docs/reverse-proxy/reverse-proxy-for-custom-docker.rst
@@ -38,7 +38,7 @@ Let's imagine you have added a custom Python Docker image to the Devilbox which 
 application listening on port ``3000``.
 
 * :ref:`env_TLD_SUFFIX`: ``loc``
-* Desired DNS name: ``my-pthon.loc``
+* Desired DNS name: ``my-python.loc``
 * :ref:`env_httpd_datadir` on the host: ``./data/www``
 * :ref:`env_httpd_template_dir`: ``.devilbox``
 * Listening port: ``3000``


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# Fix Reverse-Proxy Documentation

### Goal
<!-- What is the goal of this Pull request -->
<!-- What do you want to achieve? -->
Improve Official documentation

### DESCRIPTION

<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

While I try to put my first reverse-proxy with the Devilbox, i found procedure in official documentation. So I read all pages, and found some errors.

I suggest also to add the DNS record procedure as used by example https://devilbox.readthedocs.io/en/latest/examples/setup-reverse-proxy-nodejs.html#dns-record
into : 
- https://github.com/cytopia/devilbox/blob/master/docs/reverse-proxy/reverse-proxy-with-https.rst
- https://github.com/cytopia/devilbox/blob/master/docs/reverse-proxy/reverse-proxy-for-custom-docker.rst

Glad to help !
Laurent 