### PR TITLE
Devilbox Release v1.8.2

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v1.8.1';
-$DEVILBOX_DATE = '2020-11-12';
+$DEVILBOX_VERSION = 'v1.8.2';
+$DEVILBOX_DATE = '2020-11-14';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ major versions.
 - [#749](https://github.com/cytopia/devilbox/issues/749) Fix to disable PHP modules without `*.so` ext
 - Fixed `check-config.sh` to properly expand `~` character in path
 
+#### Added
+- [#707](https://github.com/cytopia/devilbox/issues/707) New `.env` variable: `HOST_PATH_BACKUPDIR`
+
+
 
 ## Release v1.8.1 (2020-11-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ major versions.
 ## Unreleased
 
 
+## Release v1.8.2 (2020-11-14)
+
+#### Fixed
+- [#643](https://github.com/cytopia/devilbox/issues/643) Wrong entrypoint in mysql images
+- [#703](https://github.com/cytopia/devilbox/issues/703) Don't fail on uid/gid change
+- [#749](https://github.com/cytopia/devilbox/issues/749) Fix to disable PHP modules without `*.so` ext
+- Fixed `check-config.sh` to properly expand `~` character in path
+
+
 ## Release v1.8.1 (2020-11-12)
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ major versions.
 #### Added
 - [#707](https://github.com/cytopia/devilbox/issues/707) New `.env` variable: `HOST_PATH_BACKUPDIR`
 
+#### Changed
+- [#547](https://github.com/cytopia/devilbox/issues/547) Added link to official Contao Devilbox Documentation
 
 
 ## Release v1.8.1 (2020-11-12)

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -5,7 +5,7 @@ This document will hold all information on how to update between major versions.
 
 ## Update from `v1.8.1` to `v1.8.2`
 
-**PR:** TBD
+**PR:** https://github.com/cytopia/devilbox/pull/750
 
 This PR adds many new images, ensure to remove your current old state before running them:
 ```bash

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -3,6 +3,31 @@
 This document will hold all information on how to update between major versions.
 
 
+## Update from `v1.8.1` to `v1.8.2`
+
+**PR:** TBD
+
+This PR adds many new images, ensure to remove your current old state before running them:
+```bash
+docker-compose stop
+docker-compose rm -f
+```
+
+
+## Update from `v1.8.0` to `v1.8.1`
+
+**PR:** https://github.com/cytopia/devilbox/pull/747
+
+This PR ensures to have all directories in log/ mod/ cfg/ added by default. Prior this, some
+of those directories might have been created by Docker (running as root) and they have the wrong
+permissions (root instead of local user).
+To mitigate this, you need to adjust directory permissions prior pulling this tag.
+
+```bash
+sudo chown -R <user>:<group> .
+```
+
+
 ## Update from `v1.6.2` to `v1.6.3`
 
 **PR:** https://github.com/cytopia/devilbox/pull/689

--- a/check-config.sh
+++ b/check-config.sh
@@ -504,8 +504,7 @@ fi
 #--------------------------------------------------------------------------------------------------
 print_head_1 "Checking projects"
 
-HOST_PATH_HTTPD_DATADIR="$( grep -E '^HOST_PATH_HTTPD_DATADIR=' .env | awk -F'=' '{print $2}' )"
-HOST_PATH_HTTPD_DATADIR="${HOST_PATH_HTTPD_DATADIR/#\~/${HOME}}"
+HOST_PATH_HTTPD_DATADIR="$( get_path "$( grep -E '^HOST_PATH_HTTPD_DATADIR=' .env | awk -F'=' '{print $2}' )" )"
 
 DATA_DIR_PERM_WRONG=0
 while read -r project; do

--- a/check-config.sh
+++ b/check-config.sh
@@ -361,7 +361,6 @@ print_head_1 "Checking directory permissions"
 
 DEVILBOX_DIRS=(
 	"autostart"
-	"backups"
 	"bash"
 	"ca"
 	"cfg"
@@ -426,7 +425,6 @@ print_head_1 "Checking file permissions"
 
 DEVILBOX_DIRS=(
 	"autostart"
-	"backups"
 	"ca"
 	"cfg"
 	"compose"

--- a/check-config.sh
+++ b/check-config.sh
@@ -80,6 +80,10 @@ file_get_perm() {
 	echo "${perm}"
 }
 
+get_path() {
+	echo "${1/#\~/${HOME}}"
+}
+
 
 #--------------------------------------------------------------------------------------------------
 # Check git
@@ -164,7 +168,7 @@ if [ "${DOCKER_LOGS}" != "0" ] && [ "${DOCKER_LOGS}" != "1" ]; then
 	WRONG_ENV_FILES_VALUES=1
 fi
 
-DEVILBOX_PATH="$( grep -E '^DEVILBOX_PATH=' .env | awk -F'=' '{print $2}' )"
+DEVILBOX_PATH="$( get_path "$( grep -E '^DEVILBOX_PATH=' .env | awk -F'=' '{print $2}' )" )"
 if [ ! -d "${DEVILBOX_PATH}" ]; then
 	log_err "Variable 'DEVILBOX_PATH' directory does not exist: ${DEVILBOX_PATH}"
 	RET_CODE=$(( RET_CODE + 1))
@@ -193,7 +197,7 @@ if [ "${WRONG_ENV_FILES_VALUES}" = "0" ]; then
 	log_ok "All .env file variables have correct values"
 fi
 
-HOST_PATH_HTTPD_DATADIR="$( grep -E '^HOST_PATH_HTTPD_DATADIR=' .env | awk -F'=' '{print $2}' )"
+HOST_PATH_HTTPD_DATADIR="$( get_path "$( grep -E '^HOST_PATH_HTTPD_DATADIR=' .env | awk -F'=' '{print $2}' )" )"
 if [ ! -d "${HOST_PATH_HTTPD_DATADIR}" ]; then
 	log_err "Variable 'HOST_PATH_HTTPD_DATADIR' directory does not exist: ${HOST_PATH_HTTPD_DATADIR}"
 	RET_CODE=$(( RET_CODE + 1))
@@ -501,6 +505,7 @@ fi
 print_head_1 "Checking projects"
 
 HOST_PATH_HTTPD_DATADIR="$( grep -E '^HOST_PATH_HTTPD_DATADIR=' .env | awk -F'=' '{print $2}' )"
+HOST_PATH_HTTPD_DATADIR="${HOST_PATH_HTTPD_DATADIR/#\~/${HOME}}"
 
 DATA_DIR_PERM_WRONG=0
 while read -r project; do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-0.114
+    image: devilbox/php-fpm:${PHP_SERVER}-work-0.116
     hostname: php
 
     ##

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
       # Mount DB Backup directory
-      - ${DEVILBOX_PATH}/backups:/shared/backups:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR:-./backups}:/shared/backups:rw${MOUNT_OPTIONS}
 
       # Mount devilbox user-defined *.ini files in order
       # to overwrite the default PHP.ini configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -317,7 +317,7 @@ services:
   # MySQL Database
   # ------------------------------------------------------------
   mysql:
-    image: devilbox/mysql:${MYSQL_SERVER}-0.6
+    image: devilbox/mysql:${MYSQL_SERVER}-0.7
     hostname: mysql
 
     environment:

--- a/docs/_includes/links/examples.rst
+++ b/docs/_includes/links/examples.rst
@@ -16,6 +16,12 @@
      Official Contao Documentation <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 
+.. |ext_lnk_example_contao_devilbox_documentation| raw:: html
+
+   <a target="_blank" href="https://docs.contao.org/manual/en/guides/local-installation/devilbox/">
+     Official Contao Devilbox Documentation <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
+   </a>
+
 .. |ext_lnk_example_craftcms_documentation| raw:: html
 
    <a target="_blank" href="https://docs.craftcms.com/v3/installation.html#step-1-download-craft">
@@ -28,13 +34,13 @@
      Official Drupal Documentation <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 
-.. |ext_lnk_example_expressionengine_documentation| raw:: html  
+.. |ext_lnk_example_expressionengine_documentation| raw:: html
 
    <a target="_blank" href="https://docs.expressionengine.com/latest/index.html">
      Official ExpressionEngine Documentation <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 
-.. |ext_lnk_example_expressionengine_primer| raw:: html  
+.. |ext_lnk_example_expressionengine_primer| raw:: html
 
    <a target="_blank" href="https://docs.expressionengine.com/latest/getting-started/ten-minute-primer.html">
      10 Minute Primer <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />

--- a/docs/configuration-files/env-file.rst
+++ b/docs/configuration-files/env-file.rst
@@ -959,6 +959,22 @@ always be ``/shared/httpd/``.
      ``docker-compose rm``.
 
 
+.. _env_host_path_backupdir:
+
+HOST_PATH_BACKUPDIR
+-------------------
+
+The path on your host OS of the database backup directory to be mounted into the
+PHP container into ``/shared/backups``.
+
+
++------------------------------+----------------+----------------+
+| Name                         | Allowed values | Default value  |
++==============================+================+================+
+| ``HOST_PATH_BACKUPDIR``      | valid path     | ``./backups``  |
++------------------------------+----------------+----------------+
+
+
 HOST_PATH_SSH_DIR
 -----------------
 

--- a/docs/examples/setup-contao.rst
+++ b/docs/examples/setup-contao.rst
@@ -7,6 +7,10 @@
 Setup Contao
 ************
 
+.. important::
+   **You can find a more up-to-date version in the official Contao Documentation:**
+   |ext_lnk_example_contao_devilbox_documentation|
+
 This example will use ``composer`` to install Contao CMS from within the Devilbox PHP container.
 
 .. important::
@@ -19,7 +23,9 @@ This example will use ``composer`` to install Contao CMS from within the Devilbo
 After completing the below listed steps, you will have a working Contao CMS setup ready to be
 served via http and https.
 
-.. seealso:: |ext_lnk_example_contao_documentation|
+.. seealso::
+   * |ext_lnk_example_contao_documentation|
+   * |ext_lnk_example_contao_devilbox_documentation|
 
 
 **Table of Contents**

--- a/docs/howto/devilbox/move-backups-to-different-directory.rst
+++ b/docs/howto/devilbox/move-backups-to-different-directory.rst
@@ -1,0 +1,40 @@
+:orphan:
+
+.. include:: /_includes/snippets/__ANNOUNCEMENTS__.rst
+
+.. _howto_move_backups_to_a_different_directory:
+
+*************************************
+Move backups to a different directory
+*************************************
+
+No matter if your backups are already in a different location or if you want to move them out of
+the Devilbox git directory now, you can do that in a few simple steps.
+
+**Table of Contents**
+
+.. contents:: :local:
+
+Move backups out of the Devilbox git directory
+==============================================
+
+All you have to to is to adjust the path of :ref:`env_host_path_backupdir` in the ``.env`` file.
+
+.. code-block:: bash
+
+   # Navigate to Devilbox git directory
+   host> cd path/to/devilbox
+
+   # Open the .env file with your favourite editor
+   host> vim .env
+
+Now Adjust the value of :ref:`env_host_path_backupdir`
+
+.. code-block:: bash
+   :caption: .env
+   :emphasize-lines: 1
+
+   HOST_PATH_HTTPD_DATADIR=/home/user/backups/devilbox/
+
+That's it, whenever you start up the Devilbox, ``/home/user/backups/devilbox/`` will be mounted into
+the PHP container into ``/shared/backups/``.

--- a/docs/howto/devilbox/move-backups-to-different-directory.rst
+++ b/docs/howto/devilbox/move-backups-to-different-directory.rst
@@ -18,7 +18,7 @@ the Devilbox git directory now, you can do that in a few simple steps.
 Move backups out of the Devilbox git directory
 ==============================================
 
-All you have to to is to adjust the path of :ref:`env_host_path_backupdir` in the ``.env`` file.
+All you have to do is to adjust the path of :ref:`env_host_path_backupdir` in the ``.env`` file.
 
 .. code-block:: bash
 

--- a/docs/howto/devilbox/move-projects-to-different-directory.rst
+++ b/docs/howto/devilbox/move-projects-to-different-directory.rst
@@ -22,7 +22,7 @@ So let’s assume all of your projects are already in place under ``/home/user/w
 Now you decide to use the Devilbox, but still want to keep your projects where they are at the
 moment.
 
-All you have to to is to adjust the path of :ref:`env_httpd_datadir` in the ``.env`` file.
+All you have to do is to adjust the path of :ref:`env_httpd_datadir` in the ``.env`` file.
 
 .. code-block:: bash
 

--- a/docs/intermediate/best-practice.rst
+++ b/docs/intermediate/best-practice.rst
@@ -26,13 +26,25 @@ having to worry about loosing any project data. There could also be the case tha
 dedicated hard-disk to store your projects or you have your own idea about a directory structure
 where you want to store your projects.
 
+Affected env variables to consider changing:
+
+* :ref:`env_httpd_datadir`
+* :ref:`env_host_path_backupdir`
+
 
 Projects
 --------
 
 .. seealso::
-   :ref:`howto_move_projects_to_a_different_directory`
+   * :ref:`howto_move_projects_to_a_different_directory`
      Follow this guide to keep your projects separated from the Devilbox git directory.
+
+Backups
+-------
+
+.. seealso::
+   * :ref:`howto_move_backups_to_a_different_directory`
+     Follow this guide to keep your backups separated from the Devilbox git directory.
 
 
 Version control ``.env`` file

--- a/env-example
+++ b/env-example
@@ -466,6 +466,17 @@ HOST_PATH_HTTPD_DATADIR=./data/www
 
 
 ###
+### Local filesystem path to where your backups are stored
+###
+### Note: When changing this variable you must re-create the container.
+###       Simply remove it, it will be auto-created during the next start:
+###
+### $ docker-compose rm -f
+###
+HOST_PATH_BACKUPDIR=./backups
+
+
+###
 ### The path on your host OS of the ssh directory to be mounted into the
 ### PHP container into /home/devilbox/.ssh.
 ###


### PR DESCRIPTION
## Release v1.8.2 (2020-11-14)

#### Fixed
- [#643](https://github.com/cytopia/devilbox/issues/643) Wrong entrypoint in mysql images
- [#703](https://github.com/cytopia/devilbox/issues/703) Don't fail on uid/gid change
- [#749](https://github.com/cytopia/devilbox/issues/749) Fix to disable PHP modules without `*.so` ext
- Fixed `check-config.sh` to properly expand `~` character in path

#### Added
- [#707](https://github.com/cytopia/devilbox/issues/707) New `.env` variable: `HOST_PATH_BACKUPDIR`

#### Changed
- [#547](https://github.com/cytopia/devilbox/issues/547) Added link to official Contao Devilbox Documentation
