### PR TITLE
Kibana 6.6 and above uses ELASTICSEARCH_HOSTS

### DIFF
--- a/compose/docker-compose.override.yml-all
+++ b/compose/docker-compose.override.yml-all
@@ -204,7 +204,7 @@ services:
         ipv4_address: 172.16.238.242
     environment:
       - TZ=${TIMEZONE:-UTC}
-      - ELASTICSEARCH_URL=http://elastic:9200
+      - ELASTICSEARCH_HOSTS=http://elastic:9200
     depends_on:
       - elastic
 

--- a/compose/docker-compose.override.yml-all
+++ b/compose/docker-compose.override.yml-all
@@ -205,6 +205,7 @@ services:
     environment:
       - TZ=${TIMEZONE:-UTC}
       - ELASTICSEARCH_HOSTS=http://elastic:9200
+      - ELASTICSEARCH_URL=http://elastic:9200
     depends_on:
       - elastic
 

--- a/compose/docker-compose.override.yml-elk
+++ b/compose/docker-compose.override.yml-elk
@@ -54,6 +54,7 @@ services:
     environment:
       - TZ=${TIMEZONE:-UTC}
       - ELASTICSEARCH_HOSTS=http://elastic:9200
+      - ELASTICSEARCH_URL=http://elastic:9200
     depends_on:
       - elastic
 

--- a/compose/docker-compose.override.yml-elk
+++ b/compose/docker-compose.override.yml-elk
@@ -53,7 +53,7 @@ services:
         ipv4_address: 172.16.238.242
     environment:
       - TZ=${TIMEZONE:-UTC}
-      - ELASTICSEARCH_URL=http://elastic:9200
+      - ELASTICSEARCH_HOSTS=http://elastic:9200
     depends_on:
       - elastic
 


### PR DESCRIPTION
# Kibana 6.6 and above uses ELASTICSEARCH_HOSTS

### Goal

Allow Kibana Url to load successfully by navigating to 127.0.0.1:5601

### DESCRIPTION

Kibana url will not load since it cannot connect to http://elasticsearch:9200

This is caused by Elastic Search 6.6 and above using the ELASTICSEARCH_HOSTS environment variable and not the ELASTICSEARCH_URL environment variable.

Reference 6.6 and above Documentation: https://www.elastic.co/guide/en/kibana/6.6/docker.html#docker-defaults
Reference 6.5 Documentation: https://www.elastic.co/guide/en/kibana/6.5/docker.html#docker-defaults

