### PR TITLE
Update setup-auto-dns.rst

### DIFF
--- a/docs/intermediate/setup-auto-dns.rst
+++ b/docs/intermediate/setup-auto-dns.rst
@@ -53,7 +53,7 @@ Then you need to ensure that :ref:`env_host_port_bind` is set to ``53``.
    host> vi .env
    HOST_PORT_BIND=53
 
-Before starting up the Devilbox, ensure that port ``53`` is not already used on ``127.0.0.1``.
+Before starting up the Devilbox, ensure that port ``53`` is not already used.
 
 .. code-block:: bash
    :emphasize-lines: 2


### PR DESCRIPTION
For me it has been unclear if prot 53 may not be in use in cobination to 127.0.0.1 or generally.

<!-- Add a name to your PR below -->
# FEATURE_NAME

### Goal
<!-- What is the goal of this Pull request -->
<!-- What do you want to achieve? -->


### DESCRIPTION

<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

