### PR TITLE
Fix redis args parsing for password

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -127,18 +127,26 @@ function loadClass($class) {
 				break;
 
 			case 'Redis':
-
 				// Check if redis is using a password
 				$REDIS_ROOT_PASSWORD = '';
 
 				$_REDIS_ARGS = loadClass('Helper')->getEnv('REDIS_ARGS');
 
+				/*
+				 * This pattern will match optional quoted string, 'my password' or "my password"
+				 * or if there aren't any quotes, it will match up until the next space.
+				 */
 				$_REDIS_PASS = [];
-				preg_match_all('/--requirepass\s+([^\s]*)/',  $_REDIS_ARGS, $_REDIS_PASS);
+				preg_match_all('/--requirepass\s+("|\')?(?(1)(.*)|([^\s]*))(?(1)\1|)/', $_REDIS_ARGS, $_REDIS_PASS, PREG_SET_ORDER);
 
-				if (! empty($_REDIS_PASS[1])) {
-					// In case the option is specified multiple times, use the last effective one.
-					$_REDIS_PASS = end($_REDIS_PASS[1]);
+				if (! empty($_REDIS_PASS)) {
+					/*
+					 * In case the option is specified multiple times, use the last effective one.
+					 *
+					 * preg_match_all returns a multi-dimensional array, the first level array is in order of which was matched first,
+					 * and the password string is either matched in group 2 or group 3 which is always the end of the sub-array.
+					 */
+					$_REDIS_PASS = end(end($_REDIS_PASS));
 					
 					if (strlen($_REDIS_PASS) > 0) {
 						$REDIS_ROOT_PASSWORD = $_REDIS_PASS;


### PR DESCRIPTION
# Fix redis args parsing for password

### DESCRIPTION

This should fix the issue where preg_split was being used and would cause an error if the redis args variable didn't contain the `--requirepass` string and the WebGUI wouldn't load as a result.

Here's an example of the different variations this pattern will match: https://regex101.com/r/Ms2fSa/1
