### PR TITLE
fix: show utf-8 mail body properly

### DIFF
--- a/.devilbox/www/htdocs/assets/js/html-email.js
+++ b/.devilbox/www/htdocs/assets/js/html-email.js
@@ -4,8 +4,9 @@ class HtmlEmail extends HTMLElement {
     this.attachShadow({ mode: 'open' });
 
     let emailContent;
+    const templateId = this.dataset.templateId;
     try {
-      emailContent = window.atob(this.dataset.content);
+      emailContent = document.getElementById(templateId).innerHTML;
     } catch (error) {
       console.log(error);
       return;

--- a/.devilbox/www/htdocs/mail.php
+++ b/.devilbox/www/htdocs/mail.php
@@ -186,8 +186,8 @@ $messages = $MyMbox->get($sortOrderArr);
 									<td></td>
 									<td colspan="4">
 										<?php if ($body !== null): ?>
-											<html-email data-content="<?php echo base64_encode($body) ?>">
-											</html-email>
+											<template id="mail-body-<?=$data['num']?>"><?=$body?></template>
+											<html-email data-template-id="mail-body-<?=$data['num']?>"></html-email>
 										<?php else: ?>
 											<div class="alert alert-warning" role="alert">
 												No valid body found
@@ -213,12 +213,9 @@ $messages = $MyMbox->get($sortOrderArr);
 		<?php echo loadClass('Html')->getFooter(); ?>
 		<script>
 		$(function() {
-			$('.subject').each(function() {
-				$(this).click(function() {
-					var id = ($(this).attr('id'));
-					$('#mail-'+id).toggle();
-
-				})
+			$('.subject').click(function() {
+				var id = ($(this).attr('id'));
+				$('#mail-'+id).toggle();
 			})
 			// Handler for .ready() called.
 		});


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# Improve mail with utf-8 body content

### Goal
This PR fixes #850 


### DESCRIPTION

Instead of using PHP's `encode_base64` method which doesn't supports UTF-8 properly, I render the body inside [`<template>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) tag and re-render it inside the custom element.

![image](https://user-images.githubusercontent.com/9304194/140653947-161e323b-fd85-40f8-9a2b-2c10079b6ce6.png)

