### PR TITLE
Release v1.10.1

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v1.10.0';
-$DEVILBOX_DATE = '2022-01-28';
+$DEVILBOX_VERSION = 'v1.10.1';
+$DEVILBOX_DATE = '2022-01-30';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/.devilbox/www/htdocs/mail.php
+++ b/.devilbox/www/htdocs/mail.php
@@ -24,6 +24,17 @@ require $VEN_DIR . DIRECTORY_SEPARATOR . 'Mail' . DIRECTORY_SEPARATOR .'mimeDeco
 require $LIB_DIR . DIRECTORY_SEPARATOR . 'Mail.php';
 require $LIB_DIR . DIRECTORY_SEPARATOR . 'Sort.php';
 
+
+if (isset($_GET['delete']) && is_numeric($_GET['delete'])) {
+	$message = $_GET['delete'];
+	$MyMbox = new \devilbox\Mail('/var/mail/devilbox');
+	$MyMbox->delete($message);
+	header('Location: /mail.php');
+	exit();
+}
+
+
+
 //
 // Setup Sort/Order
 //
@@ -152,6 +163,7 @@ $messages = $MyMbox->get($sortOrderArr);
 								<th>From <?php echo $orderFrom;?></th>
 								<th>To <?php echo $orderTo;?></th>
 								<th>Subject <?php echo $orderSubj;?></th>
+								<th>Action</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -180,11 +192,12 @@ $messages = $MyMbox->get($sortOrderArr);
 									<td><?php echo htmlentities($structure->headers['from']);?></td>
 									<td><?php echo htmlentities($structure->headers['x-original-to']);?></td>
 									<td><?php echo htmlentities($structure->headers['subject']);?></td>
+									<td><a href="/mail.php?delete=<?php echo $data['num']-1;?>" title="Delete Email"><i class="fa fa-trash"></i></a></td>
 								</tr>
 								<tr></tr>
 								<tr id="mail-<?php echo $data['num'];?>" style="display:none">
 									<td></td>
-									<td colspan="4">
+									<td colspan="5">
 										<?php if ($body !== null): ?>
 											<template id="mail-body-<?=$data['num']?>"><?=$body?></template>
 											<html-email data-template-id="mail-body-<?=$data['num']?>"></html-email>

--- a/.devilbox/www/include/lib/Mail.php
+++ b/.devilbox/www/include/lib/Mail.php
@@ -59,6 +59,18 @@ class Mail
 
 
 	/**
+	 * Deletes an emails
+	 *
+	 * Note: messages start with 0.
+	 *
+	 * @param int $message The number of the message to remove, or array of message ids to remove
+	 */
+	public function delete($message) {
+		$this->_Mbox->remove($message);
+	}
+
+
+	/**
 	 * Retrieve emails.
 	 *
 	 * @param  mixed[] $sort array($sort => $order) Array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
+## Release v1.10.1 (2022-01-30)
+
+
+#### Fixed
+- Fixed evaluation of `MASS_VHOST_SSL_GEN` env var [#830](https://github.com/cytopia/devilbox/issues/830)
+
+#### Added
+- Added feature to delete emails from within control center [#754](https://github.com/cytopia/devilbox/issues/754)
+
+#### Changed
+- Updated Nginx Stable [#35](https://github.com/devilbox/docker-nginx-stable/pull/35)
+- Updated Nginx Mainline [#37](https://github.com/devilbox/docker-nginx-mainline/pull/38)
+- Updated Apache 2.2 [#32](https://github.com/devilbox/docker-apache-2.2/pull/32)
+- Updated Apache 2.4 [#34](https://github.com/devilbox/docker-apache-2.4/pull/34)
+
+
 ## Release v1.10.0 (2022-01-28)
 
 #### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:0.38
+    image: devilbox/${HTTPD_SERVER}:0.39
     hostname: httpd
 
     environment:


### PR DESCRIPTION
## Release v1.10.1 (2022-01-30)


#### Fixed
- Fixed evaluation of `MASS_VHOST_SSL_GEN` env var [#830](https://github.com/cytopia/devilbox/issues/830)

#### Added
- Added feature to delete emails from within control center [#754](https://github.com/cytopia/devilbox/issues/754)

#### Changed
- Updated Nginx Stable [#35](https://github.com/devilbox/docker-nginx-stable/pull/35)
- Updated Nginx Mainline [#37](https://github.com/devilbox/docker-nginx-mainline/pull/38)
- Updated Apache 2.2 [#32](https://github.com/devilbox/docker-apache-2.2/pull/32)
- Updated Apache 2.4 [#34](https://github.com/devilbox/docker-apache-2.4/pull/34)



![Screenshot 2022-01-30 14-31-33  selection](https://user-images.githubusercontent.com/12533999/151701881-63276863-9fc0-4d47-9d99-ea056e9e7fb3.png)
