### PR TITLE
Release v1.10.2

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v1.10.1';
-$DEVILBOX_DATE = '2022-01-30';
+$DEVILBOX_VERSION = 'v1.10.2';
+$DEVILBOX_DATE = '2022-02-02';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,21 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
-## Release v1.10.1 (2022-01-30)
+## Release v1.10.2 (2022-02-02)
 
+#### Fixed
+- Fixed `nvm` PATH priority [#846](https://github.com/cytopia/devilbox/issues/846)
+
+#### Added
+- Added extension `sqlsrv` to php 8.1
+- Added extension `pdo_sqlsrv` to php 8.1
+
+#### Changed
+- Changed postfix hostname to `localhost` instead of GitHub runners long name
+- Updated PHP-FPM images [#224](https://github.com/devilbox/docker-php-fpm/pull/224)
+
+
+## Release v1.10.1 (2022-01-30)
 
 #### Fixed
 - Fixed evaluation of `MASS_VHOST_SSL_GEN` env var [#830](https://github.com/cytopia/devilbox/issues/830)

--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ The Devilbox is a development stack, so it is made sure that a lot of PHP module
 | <small>PDO_OCI</small>        |         |         |         |         |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |
 | <small>pdo_pgsql</small>      |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
 | <small>pdo_sqlite</small>     |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |
-| <small>pdo_sqlsrv</small>     |         |         |         |         |         |    d    |    d    |    d    |    d    |    d    |    d    |         |
+| <small>pdo_sqlsrv</small>     |         |         |         |         |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |
 | <small>pgsql</small>          |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
 | <small>phalcon</small>        |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |         |         |
 | <small>Phar</small>           |    🗸    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |
@@ -801,7 +801,7 @@ The Devilbox is a development stack, so it is made sure that a lot of PHP module
 | <small>SPL</small>            |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |
 | <small>SQLite</small>         |    ✔    |    ✔    |         |         |         |         |         |         |         |         |         |         |
 | <small>sqlite3</small>        |         |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |
-| <small>sqlsrv</small>         |         |         |         |         |         |    d    |    d    |    d    |    d    |    d    |    d    |         |
+| <small>sqlsrv</small>         |         |         |         |         |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |
 | <small>ssh2</small>           |         |         |         |         |         |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |         |         |
 | <small>standard</small>       |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |
 | <small>swoole</small>         |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |         |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-0.131
+    image: devilbox/php-fpm:${PHP_SERVER}-work-0.132
     hostname: php
 
     ##


### PR DESCRIPTION
## Release v1.10.2 (2022-02-02)

#### Fixed
- Fixed `nvm` PATH priority [#846](https://github.com/cytopia/devilbox/issues/846)

#### Added
- Added extension `sqlsrv` to php 8.1
- Added extension `pdo_sqlsrv` to php 8.1

#### Changed
- Changed postfix hostname to `localhost` instead of GitHub runners long name
- Updated PHP-FPM images [#224](https://github.com/devilbox/docker-php-fpm/pull/224)
