### PR TITLE
Release v1.10.4

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v1.10.3';
-$DEVILBOX_DATE = '2022-02-04';
+$DEVILBOX_VERSION = 'v1.10.4';
+$DEVILBOX_DATE = '2022-02-15';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/.devilbox/www/htdocs/mail.php
+++ b/.devilbox/www/htdocs/mail.php
@@ -5,10 +5,10 @@
 //
 // $_POST submit for sending a test email
 //
-if (isset($_GET['email']) && isset($_GET['subject']) && isset($_GET['message'])) {
-	$mail = $_GET['email'];
-	$subj = $_GET['subject'];
-	$mess = $_GET['message'];
+if (isset($_POST['email']) && isset($_POST['subject']) && isset($_POST['message'])) {
+	$mail = $_POST['email'];
+	$subj = $_POST['subject'];
+	$mess = $_POST['message'];
 	if (! mail($mail, $subj, $mess)) {
 		loadClass('Logger')->error('Could not send mail to: '.$mail.' | subject: '.$subj);
 	}
@@ -119,7 +119,7 @@ $messages = $MyMbox->get($sortOrderArr);
 			<div class="row">
 				<div class="col-md-12">
 
-					<form class="form-inline">
+					<form method="post" class="form-inline">
 						<div class="form-group">
 							<label class="sr-only" for="exampleInputEmail1">Email to</label>
 							<input name="email" type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter to email">
@@ -132,7 +132,7 @@ $messages = $MyMbox->get($sortOrderArr);
 
 						<div class="form-group">
 							<label class="sr-only" for="exampleInputEmail3">Message</label>
-							<input name="message" type="text" class="form-control" id="exampleInputEmail3" placeholder="Message">
+							<textarea name="message" rows="1" class="form-control" id="exampleInputEmail3" placeholder="Message"></textarea>
 						</div>
 
 						<button type="submit" class="btn btn-primary">Send Email</button>

--- a/.devilbox/www/include/lib/container/Httpd.php
+++ b/.devilbox/www/include/lib/container/Httpd.php
@@ -39,7 +39,7 @@ class Httpd extends BaseClass implements BaseInterface
 		$err = false;
 		if (!$this->canConnect($err, $domain)) {
 			$error[] = 'warning';
-			$error[] = 'DNS server not running.<br/>You won\'t be able to work inside the PHP container.';
+			$error[] = 'Cannot connect to '.$domain.'.<br/>DNS server not running?<br/>You won\'t be able to work inside the PHP container.';
 		}
 
 		if (is_array($error) && count($error)) {

--- a/.tests/tests/intranet-email.sh
+++ b/.tests/tests/intranet-email.sh
@@ -66,7 +66,7 @@ MY_MESS="testing-ci-message"
 run "docker-compose exec --user devilbox -T php bash -c '> /var/mail/devilbox'" "${RETRIES}" "${DVLBOX_PATH}"
 
 # Send a new mail
-run "curl -sS --fail -XPOST 'http://localhost:${HOST_PORT_HTTPD}/mail.php?email=${MY_MAIL}&subject=${MY_SUBJ}&message=${MY_MESS}'" "${RETRIES}"
+run "curl -sS --fail -XPOST 'http://localhost:${HOST_PORT_HTTPD}/mail.php' -d 'email=${MY_MAIL}&subject=${MY_SUBJ}&message=${MY_MESS}'" "${RETRIES}"
 
 # Validate
 run "curl -sS --fail 'http://localhost:${HOST_PORT_HTTPD}/mail.php' | tac | tac | grep '${MY_MAIL}' >/dev/null" "${RETRIES}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
+## Release v1.10.4 (2022-02-15)
+
+#### Fixed
+- Fixed SSL-Cache Mutex on M1 CPU [#862](https://github.com/cytopia/devilbox/issues/862)
+
+#### Changed
+- Updated Nginx Stable [#36](https://github.com/devilbox/docker-nginx-stable/pull/36)
+- Updated Nginx Mainline [#39](https://github.com/devilbox/docker-nginx-mainline/pull/39)
+- Updated Apache 2.2 [#33](https://github.com/devilbox/docker-apache-2.2/pull/33)
+- Updated Apache 2.4 [#35](https://github.com/devilbox/docker-apache-2.4/pull/35)
+
+
 ## Release v1.10.3 (2022-02-04)
 
 #### Added
@@ -40,7 +52,7 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 
 #### Changed
 - Updated Nginx Stable [#35](https://github.com/devilbox/docker-nginx-stable/pull/35)
-- Updated Nginx Mainline [#37](https://github.com/devilbox/docker-nginx-mainline/pull/38)
+- Updated Nginx Mainline [#38](https://github.com/devilbox/docker-nginx-mainline/pull/38)
 - Updated Apache 2.2 [#32](https://github.com/devilbox/docker-apache-2.2/pull/32)
 - Updated Apache 2.4 [#34](https://github.com/devilbox/docker-apache-2.4/pull/34)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 - Fixed SSL-Cache Mutex on M1 CPU [#862](https://github.com/cytopia/devilbox/issues/862)
 
 #### Changed
+- Changed Intranet mail tester to using POST instead of GET for larger body size
+- Made vhost error message more verbose
 - Updated Nginx Stable [#36](https://github.com/devilbox/docker-nginx-stable/pull/36)
 - Updated Nginx Mainline [#39](https://github.com/devilbox/docker-nginx-mainline/pull/39)
 - Updated Apache 2.2 [#33](https://github.com/devilbox/docker-apache-2.2/pull/33)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:0.39
+    image: devilbox/${HTTPD_SERVER}:0.40
     hostname: httpd
 
     environment:


### PR DESCRIPTION
## Release v1.10.4 (2022-02-15)

#### Fixed
- Fixed SSL-Cache Mutex on M1 CPU [#862](https://github.com/cytopia/devilbox/issues/862)

#### Changed
- Changed Intranet mail tester to using POST instead of GET for larger body size
- Made vhost error message more verbose
- Updated Nginx Stable [#36](https://github.com/devilbox/docker-nginx-stable/pull/36)
- Updated Nginx Mainline [#39](https://github.com/devilbox/docker-nginx-mainline/pull/39)
- Updated Apache 2.2 [#33](https://github.com/devilbox/docker-apache-2.2/pull/33)
- Updated Apache 2.4 [#35](https://github.com/devilbox/docker-apache-2.4/pull/35)
