### PR TITLE
Release v2.1.0

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v2.0.0';
-$DEVILBOX_DATE = '2022-03-28';
+$DEVILBOX_VERSION = 'v2.1.0';
+$DEVILBOX_DATE = '2022-04-03';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -14,7 +14,7 @@ putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
 $DEVILBOX_VERSION = 'v2.1.0';
-$DEVILBOX_DATE = '2022-04-03';
+$DEVILBOX_DATE = '2022-04-05';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
+## Release v2.1.0 (2022-04-03)
+
+This is now a 100% `arm64` compatible release.
+
+#### Fixed
+- Fixed imklog: cannot open kernel log (/proc/kmsg): Operation not permitted.
+- Fixed missing `arm64` support: [#855](https://github.com/cytopia/devilbox/issues/855)
+
+#### Added
+- Added PHP images with `arm64` support for PHP: https://github.com/devilbox/docker-php-fpm/releases/tag/0.138
+- Added `vips` to PHP 8.0
+- Added `vips` to PHP 8.1
+- Added `swoole` to PHP 8.1
+
+#### Removed
+- Removed homebrew due to arm64 issues
+- Removed postgres cmd client and apt repositories due to arm64 issues
+- Removed mongodb cmd client and apt repositories due to arm64 issues
+- Removed Ansible due to arm64 issues
+
+
 ## Release v2.0.0 (2022-03-28)
 
 The goal of this release is to reduce the overall size of Docker images and bring in latest versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
-## Release v2.1.0 (2022-04-03)
+## Release v2.1.0 (2022-04-05)
 
 This is now a 100% `arm64` compatible release.
 
@@ -22,8 +22,6 @@ This is now a 100% `arm64` compatible release.
 
 #### Removed
 - Removed homebrew due to arm64 issues
-- Removed postgres cmd client and apt repositories due to arm64 issues
-- Removed mongodb cmd client and apt repositories due to arm64 issues
 - Removed Ansible due to arm64 issues
 
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 [![PgSQL](https://github.com/cytopia/devilbox/actions/workflows/test-pgsql.yml/badge.svg)](https://github.com/cytopia/devilbox/actions/workflows/test-pgsql.yml)
 [![Redis](https://github.com/cytopia/devilbox/actions/workflows/test-redis.yml/badge.svg)](https://github.com/cytopia/devilbox/actions/workflows/test-redis.yml)
 
+**Available Architectures:**  `amd64`, `arm64`
 
 <img width="200" style="width:200px;" src="docs/_includes/figures/https/https-ssl-address-bar.png" /><br/>
 <small><sub>Support for <a href="https://devilbox.readthedocs.io/en/latest/intermediate/setup-valid-https.html">valid https</a> out of the box.</sub></small>
@@ -821,7 +822,7 @@ The Devilbox is a development stack, so it is made sure that a lot of PHP module
 | <sup>sqlsrv</sup>             |         |         |         |         |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |
 | <sup>ssh2</sup>               |         |         |         |         |         |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |         |         |         |
 | <sup>standard</sup>           |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |
-| <sup>swoole</sup>             |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |         |         |
+| <sup>swoole</sup>             |         |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |    d    |         |
 | <sup>sysvmsg</sup>            |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
 | <sup>sysvsem</sup>            |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
 | <sup>sysvshm</sup>            |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
@@ -829,7 +830,7 @@ The Devilbox is a development stack, so it is made sure that a lot of PHP module
 | <sup>tokenizer</sup>          |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |    ✔    |
 | <sup>uploadprogress</sup>     |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
 | <sup>uuid</sup>               |         |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
-| <sup>vips</sup>               |         |         |         |         |         |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |         |         |         |
+| <sup>vips</sup>               |         |         |         |         |         |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |         |
 | <sup>wddx</sup>               |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |         |         |         |         |
 | <sup>xdebug</sup>             |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |
 | <sup>xlswriter</sup>          |         |         |         |         |         |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |    🗸    |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-0.136
+    image: devilbox/php-fpm:${PHP_SERVER}-work-0.138
     hostname: php
 
     ##

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-0.138
+    image: devilbox/php-fpm:${PHP_SERVER}-work-release-0.139
     hostname: php
 
     ##


### PR DESCRIPTION
## Release v2.1.0 (2022-04-05)

This is now a 100% `arm64` compatible release.

#### Fixed
- Fixed PHP image rsyslog error `imklog: cannot open kernel log (/proc/kmsg): Operation not permitted`.
- Fixed missing `arm64` support: [#855](https://github.com/cytopia/devilbox/issues/855)

#### Added
- Added PHP images with `arm64` support for PHP: https://github.com/devilbox/docker-php-fpm/releases/tag/0.138
- Added PHP images with `arm64` support for PHP: https://github.com/devilbox/docker-php-fpm/releases/tag/0.139
- Added `vips` to PHP 8.0
- Added `vips` to PHP 8.1
- Added `swoole` to PHP 8.1

#### Removed
- Removed homebrew due to arm64 issues
- Removed Ansible due to arm64 issues
