### PR TITLE
Release v2.1.1

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v2.1.0';
-$DEVILBOX_DATE = '2022-04-05';
+$DEVILBOX_VERSION = 'v2.1.1';
+$DEVILBOX_DATE = '2022-04-07';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
+## Release v2.1.1 (2022-04-07)
+
+#### Changed
+- Used tagged PHP images (auto-updating)instead early release branch one.
+
+
 ## Release v2.1.0 (2022-04-05)
 
 This is now a 100% `arm64` compatible release.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-release-0.139
+    image: devilbox/php-fpm:${PHP_SERVER}-work-0.139
     hostname: php
 
     ##


### PR DESCRIPTION
## Release v2.1.1 (2022-04-07)

The previous v2.1.0 release was using the php docker images from the release branch (as building others takes >9 hours). This one fixes it and uses the git tagged images, which are rebuild every two days.

#### Changed
- Used tagged PHP images (auto-updating)instead early release branch one.
