### PR TITLE
fix typo

### DIFF
--- a/docs/getting-started/install-the-devilbox.rst
+++ b/docs/getting-started/install-the-devilbox.rst
@@ -44,7 +44,7 @@ copied to a file named ``.env``. (Pay attention to the leading dot).
 
    host> cp env-example .env
 
-The ``.env`` file does nothing else then providing environment variables for Docker Compose
+The ``.env`` file does nothing else than providing environment variables for Docker Compose
 and in this case it is used as the main configuration file for the Devilbox by providing all kinds
 of settings (such as which version to start up).
 


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# fix typo - grammar mistake

### Goal

Fix a grammar mistake


### DESCRIPTION

The word 'than' is used for comparisons. The word 'then' is used for sequence of events.

