### PR TITLE
docs: fix CodeIgniter3 docs link

### DIFF
--- a/docs/_includes/links/examples.rst
+++ b/docs/_includes/links/examples.rst
@@ -4,9 +4,9 @@
      Official CakePHP Documentation <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 
-.. |ext_lnk_example_codeignitor_documentation| raw:: html
+.. |ext_lnk_example_codeigniter_documentation| raw:: html
 
-   <a target="_blank" href="https://www.codeigniter.com/user_guide/installation/index.html">
+   <a target="_blank" href="https://www.codeigniter.com/userguide3/installation/index.html">
      Official CodeIgniter Documentation <img src="https://raw.githubusercontent.com/cytopia/icons/master/11x11/ext-link.png" />
    </a>
 

--- a/docs/examples/setup-codeigniter.rst
+++ b/docs/examples/setup-codeigniter.rst
@@ -12,7 +12,7 @@ This example will use ``wget`` to install CodeIgniter from within the Devilbox P
 After completing the below listed steps, you will have a working CodeIgniter setup ready to be
 served via http and https.
 
-.. seealso:: |ext_lnk_example_codeignitor_documentation|
+.. seealso:: |ext_lnk_example_codeigniter_documentation|
 
 
 **Table of Contents**


### PR DESCRIPTION
https://devilbox.readthedocs.io/en/latest/examples/setup-codeigniter.html is an example for CodeIgniter v3.
But the link to [Official CodeIgniter Documentation](https://www.codeigniter.com/user_guide/installation/index.html) is the user guide of CodeIgniter v4.

This PR fixes the link URL.