### PR TITLE
Fix rabbit container name typo in docs

### DIFF
--- a/docs/custom-container/enable-rabbitmq.rst
+++ b/docs/custom-container/enable-rabbitmq.rst
@@ -136,7 +136,7 @@ Let's assume you want to start ``php``, ``httpd``, ``bind``, ``rabbit``.
 
 .. code-block:: bash
 
-   host> docker-compose up -d php httpd bind rabbitmq
+   host> docker-compose up -d php httpd bind rabbit
 
 .. seealso:: :ref:`start_the_devilbox`
 


### PR DESCRIPTION
# Fix rabbit container name typo in docs

### Goal

Fixing documentation


### DESCRIPTION

Fixed a typo in the name of the rabbit container

