### PR TITLE
Update .gitignore to ignore anything in /data/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 /backups/*
 
 # Ignore Data dirs
-/data/www/*
+/data/*
 
 # Ignore Certificate Authority
 /ca/*


### PR DESCRIPTION
Don't know if this even qualifies as PR :) , and if this is acceptable, but I find it very useful to override few services via `docker-compose.override.yml` to map data dirs from containers to local volumes and put them inside `./data/` And by putting them next `./data/www/` this makes devilbox installations very compact.

eg.
```
  mysql:
    volumes:
      - ${DEVILBOX_PATH}/data/${MYSQL_SERVER}:/var/lib/mysql:rw${MOUNT_OPTIONS}
    user: mysql
  mongo:
    volumes:
      - ${DEVILBOX_PATH}/data/mongo-${MONGO_SERVER}:/data/db:rw${MOUNT_OPTIONS}
```
