### PR TITLE
Release/v3.0.0 beta 0.2

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -14,7 +14,7 @@ putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
 $DEVILBOX_VERSION = 'v3.0.0-beta-0.2';
-$DEVILBOX_DATE = '2022-12-26';
+$DEVILBOX_DATE = '2022-12-27';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v3.0.0-beta-0.1';
-$DEVILBOX_DATE = '2022-12-24';
+$DEVILBOX_VERSION = 'v3.0.0-beta-0.2';
+$DEVILBOX_DATE = '2022-12-26';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/.devilbox/www/htdocs/vhosts.php
+++ b/.devilbox/www/htdocs/vhosts.php
@@ -83,7 +83,7 @@
 					var el_valid;
 					var el_href;
 
-					if (this.readyState == 4 && this.status == 200) {
+					if (this.readyState == 4 && this.status == 200 || this.status == 426) {
 						el_valid = document.getElementById('valid-' + vhost);
 						el_href = document.getElementById('href-' + vhost);
 						error = this.responseText;

--- a/.devilbox/www/htdocs/vhosts.php
+++ b/.devilbox/www/htdocs/vhosts.php
@@ -31,13 +31,6 @@
 								</tr>
 							</thead>
 							<tbody>
-								<?php
-									$totals = 0;
-									$filler = '&nbsp;';
-									for ($i=0; $i<$totals; $i++) {
-										$filler = $filler. '&nbsp;';
-									}
-								?>
 								<?php foreach ($vHosts as $vHost): ?>
 									<tr>
 										<td><?php echo $vHost['name'];?></td>
@@ -46,11 +39,13 @@
 										<td>
 											<a title="Virtual host: <?php echo $vHost['name'];?>.conf" target="_blank" href="/vhost.d/<?php echo $vHost['name'];?>.conf"><i class="fa fa-cog" aria-hidden="true"></i></a>
 											<?php if (($vhostGen = loadClass('Httpd')->getVhostgenTemplatePath($vHost['name'])) !== false): ?>
-												<a title="vhost-gen: <?php echo basename($vhostGen);?> for <?php echo $vHost['name'];?>" href="/info_vhostgen.php?name=<?php echo $vHost['name'];?>"><i class="fa fa-filter" aria-hidden="true"></i></a>
+												<a title="vhost-gen: <?php echo basename($vhostGen);?> for <?php echo $vHost['name'];?>" href="/info_vhostgen.php?name=<?php echo $vHost['name'];?>">
+													<i class="fa fa-filter" aria-hidden="true"></i>
+												</a>
 											<?php endif; ?>
 										</td>
-										<td class="text-xs-center text-xs-small" id="valid-<?php echo $vHost['name'];?>">&nbsp;&nbsp;&nbsp;</td>
-										<td id="href-<?php echo $vHost['name'];?>"><?php echo $filler;?></td>
+										<td style="min-width:60px;" class="text-xs-center text-xs-small" id="valid-<?php echo $vHost['name'];?>"></td>
+										<td style="min-width:260px;" id="href-<?php echo $vHost['name'];?>"></td>
 									</tr>
 									<input type="hidden" name="vhost[]" class="vhost" value="<?php echo $vHost['name'];?>" />
 								<?php endforeach; ?>
@@ -135,7 +130,8 @@
 						if (el_valid.innerHTML != 'WARN') {
 							el_valid.innerHTML = 'OK';
 						}
-						el_href.innerHTML = '<a target="_blank" href="'+proto+'//'+name+port+'">'+name+port+'</a>' + el_href.innerHTML;
+						//el_href.innerHTML = '(<a target="_blank" href="'+proto+'//localhost/devilbox-project/'+name+'">ext</a>) <a target="_blank" href="'+proto+'//'+name+port+'">'+name+port+'</a>' + el_href.innerHTML;
+						el_href.innerHTML = '<a target="_blank" href="'+proto+'//'+name+port+'">'+name+port+'</a>';
 					} else {
 						//console.log(vhost);
 					}

--- a/.devilbox/www/htdocs/vhosts.php
+++ b/.devilbox/www/htdocs/vhosts.php
@@ -129,7 +129,7 @@
 					var el_href = document.getElementById('href-' + vhost);
 					var error = this.responseText;
 
-					if (this.readyState == 4 && this.status == 200) {
+					if (this.readyState == 4 && (this.status == 200 || this.status == 426)) {
 						clearTimeout(xmlHttpTimeout);
 						el_valid.className += ' bg-success';
 						if (el_valid.innerHTML != 'WARN') {

--- a/.devilbox/www/htdocs/vhosts.php
+++ b/.devilbox/www/htdocs/vhosts.php
@@ -60,6 +60,60 @@
 				</div>
 			</div>
 
+			<?php
+			$cmd="netstat -wneeplt 2>/dev/null | sort | grep '\s1000\s' | awk '{print \"app=\"\$9\"|addr=\"\$4}' | sed 's/\(app=\)\([0-9]*\/\)/\\1/g' | sed 's/\(.*\)\(:[0-9][0-9]*\)/\\1|port=\\2/g' | sed 's/port=:/port=/g'";
+			$output=loadClass('Helper')->exec($cmd);
+			$daemons = array();
+			foreach (preg_split("/((\r?\n)|(\r\n?))/", $output) as $line) {
+				$section = preg_split("/\|/", $line);
+				if (count($section) == 3) {
+					$tool = preg_split("/=/", $section[0]);
+					$addr = preg_split("/=/", $section[1]);
+					$port = preg_split("/=/", $section[2]);
+					$tool = $tool[1];
+					$addr = $addr[1];
+					$port = $port[1];
+					$daemons[] = array(
+						'tool' => $tool,
+						'addr' => $addr,
+						'port' => $port
+					);
+				}
+			}
+			?>
+			<?php if (count($daemons)): ?>
+			<br/>
+			<br/>
+			<div class="row">
+				<div class="col-md-12">
+
+					<h2>Local listening daemons</h2>
+					<table class="table table-striped">
+						<thead class="thead-inverse">
+							<tr>
+								<th>Application</th>
+								<th>Listen Address</th>
+								<th>Listen Port</th>
+								<th>Host</th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($daemons as $daemon): ?>
+								<tr>
+									<td><?php echo $daemon['tool']; ?></td>
+									<td><?php echo $daemon['addr']; ?></td>
+									<td><?php echo $daemon['port']; ?></td>
+									<td>php (172.16.238.10)</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+			</div>
+			<?php endif; ?>
+
+
+
 		</div><!-- /.container -->
 
 		<?php echo loadClass('Html')->getFooter(); ?>

--- a/.devilbox/www/include/lib/container/Httpd.php
+++ b/.devilbox/www/include/lib/container/Httpd.php
@@ -29,10 +29,18 @@ class Httpd extends BaseClass implements BaseInterface
 		$url		= 'http://'.$domain;
 		$error		= array();
 
-		// 1. Check htdocs folder
-		if (!$this->_is_valid_dir($docroot)) {
-			$error[] = 'error';
-			$error[] = 'Missing <strong>'.$htdocs.'</strong> directory in: <strong>'.loadClass('Helper')->getEnv('HOST_PATH_HTTPD_DATADIR').'/'.$vhost.'/</strong>';
+
+		$backend    = $this->getVhostBackend($vhost);
+		$pos_def    = strpos($backend, 'default');
+		$pos_phpfpm = strpos($backend, 'tcp://');
+
+		// Only if backend 'default' or 'phpfpm', we need a htdocs/ directory
+		if ( ($pos_def !== false && $pos_def == 0) || ($pos_phpfpm !== false && $pos_phpfpm == 0) ) {
+			// 1. Check htdocs folder
+			if (!$this->_is_valid_dir($docroot)) {
+				$error[] = 'error';
+				$error[] = 'Missing <strong>'.$htdocs.'</strong> directory in: <strong>'.loadClass('Helper')->getEnv('HOST_PATH_HTTPD_DATADIR').'/'.$vhost.'/</strong>';
+			}
 		}
 
 		// 2. Check internal DNS server

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,7 +36,7 @@ jobs:
         target:
           - build
           - linkcheck
-          - linkcheck2
+          # - linkcheck2
 
     name: "[Docs ${{ matrix.target }}]"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
+## Release v3.0.0-beta-0.2 (2022-12-26)
+
+The Backend configuration now supports websockets as well:
+
+file: `/shared/httpd/<project>/.devilbox/backend.cfg`
+```bash
+# PHP-FPM backend
+conf:phpfpm:tcp:php80:9000
+
+# HTTP Reverse Proxy backend
+conf:rproxy:http:172.16.238.10:3000
+
+# HTTPS Reverse Proxy backend
+conf:rproxy:https:172.16.238.10:3000
+
+# Websocket Reverse Proxy backend
+conf:rproxy:ws:172.16.238.10:3000
+
+# SSL Websocket Reverse Proxy backend
+conf:rproxy:wss:172.16.238.10:3000
+```
+
+Once you're done with `backend.cfg` changes, head over to the Intranet C&C page (http://localhost/cnc.php) and Reload `watcherd`.
+
+
+### Fixed
+- Intranet: vhost overview: allow HTTP 426 to succeed in vhost page (websocket projects)
+- Intranet: vhost overview: Reverse Proxy or Websocket backends do not require a `htdocs/` dir for healthcheck
+- Fixed reverse proxy template generation for Apache 2.2 and Apache 2.4 [vhost-gen #51](https://github.com/devilbox/vhost-gen/pull/51)
+- Fixed Nginx hash bucket size length to allow long hostnames
+
+### Added
+- Reverse Proxy automation for websocket projects (`ws://<host>:<port>` or `wss:<host>:<port>`) (Does not work with Apache 2.2)
+- Added tool `wscat` to be able to test websocket connections
+- Intranet: vhost overview now also shows websocket projects
+
+### Changed
+- Do not mount any startup/autostart script directories for multi-php compose as they do not contain tools
+
+
 ## Release v3.0.0-beta-0.1 (2022-12-24) 🎅🎄🎁
 
 This is a beta release, using a completely rewritten set of HTTPD server, which allow easy reverse Proxy integration and different PHP versions per project:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Once you're done with `backend.cfg` changes, head over to the Intranet C&C page 
 
 ### Changed
 - Do not mount any startup/autostart script directories for multi-php compose as they do not contain tools
+- Updated vhost-gen templates in `cfg/vhost-gen` (replace your project templates with new ones)
 
 
 ## Release v3.0.0-beta-0.1 (2022-12-24) 🎅🎄🎁

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
-## Release v3.0.0-beta-0.2 (2022-12-26)
+## Release v3.0.0-beta-0.2 (2022-12-27)
 
 The Backend configuration now supports websockets as well:
 

--- a/cfg/vhost-gen/apache22.yml-example-rproxy
+++ b/cfg/vhost-gen/apache22.yml-example-rproxy
@@ -46,10 +46,10 @@ vhost: |
       ErrorLog   "__ERROR_LOG__"
 
       # Reverse Proxy definition (Ensure to adjust the port, currently '8000')
-      ProxyRequests On
+      ProxyRequests     Off
       ProxyPreserveHost On
-      ProxyPass / http://php:8000/
-      ProxyPassReverse / http://php:8000/
+      ProxyPass         / http://php:8000/ retry=0
+      ProxyPassReverse  / http://php:8000/
 
   __REDIRECT__
   __SSL__
@@ -92,6 +92,7 @@ features:
     # Alias Definition
     Alias "__ALIAS__" "__PATH____ALIAS__"
     <Location "__ALIAS__">
+        ProxyPass !
     __XDOMAIN_REQ__
     </Location>
     <Directory "__PATH____ALIAS__">

--- a/cfg/vhost-gen/apache22.yml-example-rproxy
+++ b/cfg/vhost-gen/apache22.yml-example-rproxy
@@ -34,9 +34,22 @@
 #    __ERROR_LOG__
 #
 
+###
+### Notes about Apache
+###
+
+#
+# 1. Each same directive is checked in order of definition (last one wins)
+# 2. Directives are ordered: Directory, DirectoryMatch, Files, and finally Location (last one wins)
+#   * Last match always takes precedence
+#
+# Exception: Directories, where shortest path is matched first
+# Exception: ProxyPass and Alias first match and then stops
 
 ###
 ### Basic vHost skeleton
+###
+### Note: Reverse Proxy section must be last for Apache 2.2
 ###
 vhost: |
   <VirtualHost __DEFAULT_VHOST__:__PORT__>
@@ -45,11 +58,17 @@ vhost: |
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"
 
-      # Reverse Proxy definition (Ensure to adjust the port, currently '8000')
+      # ProxyRequests:     Disable "Forward Proxy"
+      # ProxyPreserveHost: Pass "Host" header to remote
+      # ProxyVia:          Add "Via" header
       ProxyRequests     Off
       ProxyPreserveHost On
-      ProxyPass         / http://php:8000/ retry=0
-      ProxyPassReverse  / http://php:8000/
+      ProxyVia          On
+      <Location />
+          # Reverse Proxy definition (Ensure to adjust the port, currently '8000')
+          ProxyPass         http://php:8000/ retry=0
+          ProxyPassReverse  http://php:8000/
+      </Location>
 
   __REDIRECT__
   __SSL__
@@ -102,10 +121,10 @@ features:
 
   deny: |
     # Deny Definition
-    <FilesMatch "__REGEX__">
+    <LocationMatch "__REGEX__">
         Order allow,deny
         Deny from all
-    </FilesMatch>
+    </LocationMatch>
 
   server_status: |
     # Status Page

--- a/cfg/vhost-gen/apache22.yml-example-vhost
+++ b/cfg/vhost-gen/apache22.yml-example-vhost
@@ -40,9 +40,22 @@
 #    __PHP_PORT__
 #
 
+###
+### Notes about Apache
+###
+
+#
+# 1. Each same directive is checked in order of definition (last one wins)
+# 2. Directives are ordered: Directory, DirectoryMatch, Files, and finally Location (last one wins)
+#   * Last match always takes precedence
+#
+# Exception: Directories, where shortest path is matched first
+# Exception: ProxyPass and Alias first match and then stops
 
 ###
 ### Basic vHost skeleton
+###
+### Note: Reverse Proxy section must be last for Apache 2.2
 ###
 vhost: |
   <VirtualHost __DEFAULT_VHOST__:__PORT__>
@@ -57,10 +70,10 @@ vhost: |
   __PHP_FPM__
   __ALIASES__
   __DENIES__
-  __VHOST_RPROXY__
   __SERVER_STATUS__
       # Custom directives
   __CUSTOM__
+  __VHOST_RPROXY__
   </VirtualHost>
 
 ###
@@ -86,28 +99,36 @@ vhost_type:
 
   # Reverse Proxy (-r http(s)://ADDR:PORT)
   rproxy: |
-    # Define Reverse Proxy
+    # ProxyRequests:     Disable "Forward Proxy"
+    # ProxyPreserveHost: Pass "Host" header to remote
+    # ProxyVia:          Add "Via" header
     ProxyRequests     Off
     ProxyPreserveHost On
-    ProxyPass         __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
-    ProxyPassReverse  __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+    ProxyVia          On
+    <Location __LOCATION__>
+        # Reverse Proxy
+        ProxyPass         __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
+        ProxyPassReverse  __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+    </Location>
 
   # Reverse Proxy with websocket support (-r ws(s)://ADDR:PORT)
   rproxy_ws: |
-    # Define Reverse Proxy with Websock support
+    # ProxyRequests:     Disable "Forward Proxy"
+    # ProxyPreserveHost: Pass "Host" header to remote
+    # ProxyVia:          Add "Via" header
     ProxyRequests     Off
     ProxyPreserveHost On
-    <location __LOCATION__>
+    ProxyVia          On
+    <Location __LOCATION__>
         # Websocket Rewrite Settings
         RewriteEngine On
         RewriteCond %{HTTP:Connection} Upgrade   [NC]
         RewriteCond %{HTTP:Upgrade}    websocket [NC]
         RewriteRule ^/?(.*)$ __WS_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/$1 [P,L]
-
-        # Reverse Proxy Settings
+        # Reverse Proxy
         ProxyPass         __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
         ProxyPassReverse  __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
-    </location>
+    </Location>
 
 
 ###
@@ -147,10 +168,10 @@ features:
 
   deny: |
     # Deny Definition
-    <FilesMatch "__REGEX__">
+    <LocationMatch "__REGEX__">
         Order allow,deny
         Deny from all
-    </FilesMatch>
+    </LocationMatch>
 
   server_status: |
     # Status Page

--- a/cfg/vhost-gen/apache22.yml-example-vhost
+++ b/cfg/vhost-gen/apache22.yml-example-vhost
@@ -54,10 +54,10 @@ vhost: |
   __REDIRECT__
   __SSL__
   __VHOST_DOCROOT__
-  __VHOST_RPROXY__
   __PHP_FPM__
   __ALIASES__
   __DENIES__
+  __VHOST_RPROXY__
   __SERVER_STATUS__
       # Custom directives
   __CUSTOM__
@@ -84,13 +84,30 @@ vhost_type:
         Allow from all
     </Directory>
 
-  # Reverse Proxy (-r)
+  # Reverse Proxy (-r http(s)://ADDR:PORT)
   rproxy: |
-    # Define the vhost to reverse proxy
-    ProxyRequests On
+    # Define Reverse Proxy
+    ProxyRequests     Off
     ProxyPreserveHost On
-    ProxyPass __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT____LOCATION__
-    ProxyPassReverse __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT____LOCATION__
+    ProxyPass         __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
+    ProxyPassReverse  __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+
+  # Reverse Proxy with websocket support (-r ws(s)://ADDR:PORT)
+  rproxy_ws: |
+    # Define Reverse Proxy with Websock support
+    ProxyRequests     Off
+    ProxyPreserveHost On
+    <location __LOCATION__>
+        # Websocket Rewrite Settings
+        RewriteEngine On
+        RewriteCond %{HTTP:Connection} Upgrade   [NC]
+        RewriteCond %{HTTP:Upgrade}    websocket [NC]
+        RewriteRule ^/?(.*)$ __WS_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/$1 [P,L]
+
+        # Reverse Proxy Settings
+        ProxyPass         __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
+        ProxyPassReverse  __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+    </location>
 
 
 ###
@@ -120,6 +137,7 @@ features:
     # Alias Definition
     Alias "__ALIAS__" "__PATH____ALIAS__"
     <Location "__ALIAS__">
+        ProxyPass !
     __XDOMAIN_REQ__
     </Location>
     <Directory "__PATH____ALIAS__">

--- a/cfg/vhost-gen/apache24.yml-example-rproxy
+++ b/cfg/vhost-gen/apache24.yml-example-rproxy
@@ -47,10 +47,10 @@ vhost: |
       ErrorLog   "__ERROR_LOG__"
 
       # Reverse Proxy definition (Ensure to adjust the port, currently '8000')
-      ProxyRequests On
+      ProxyRequests     Off
       ProxyPreserveHost On
-      ProxyPass / http://php:8000/
-      ProxyPassReverse / http://php:8000/
+      ProxyPass         / http://php:8000/ retry=0
+      ProxyPassReverse  / http://php:8000/
 
   __REDIRECT__
   __SSL__
@@ -93,6 +93,7 @@ features:
     # Alias Definition
     Alias "__ALIAS__" "__PATH____ALIAS__"
     <Location "__ALIAS__">
+        ProxyPass !
     __XDOMAIN_REQ__
     </Location>
     <Directory "__PATH____ALIAS__">

--- a/cfg/vhost-gen/apache24.yml-example-rproxy
+++ b/cfg/vhost-gen/apache24.yml-example-rproxy
@@ -34,6 +34,17 @@
 #    __ERROR_LOG__
 #
 
+###
+### Notes about Apache
+###
+
+#
+# 1. Each same directive is checked in order of definition (last one wins)
+# 2. Directives are ordered: Directory, DirectoryMatch, Files, and finally Location (last one wins)
+#   * Last match always takes precedence
+#
+# Exception: Directories, where shortest path is matched first
+# Exception: ProxyPass and Alias first match and then stops
 
 ###
 ### Basic vHost skeleton
@@ -46,11 +57,19 @@ vhost: |
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"
 
-      # Reverse Proxy definition (Ensure to adjust the port, currently '8000')
+      # ProxyRequests:     Disable "Forward Proxy"
+      # ProxyPreserveHost: Pass "Host" header to remote
+      # ProxyAddHeaders:   Add "X-Forward-*" headers
+      # ProxyVia:          Add "Via" header
       ProxyRequests     Off
       ProxyPreserveHost On
-      ProxyPass         / http://php:8000/ retry=0
-      ProxyPassReverse  / http://php:8000/
+      ProxyAddHeaders   On
+      ProxyVia          On
+      <Location />
+          # Reverse Proxy definition (Ensure to adjust the port, currently '8000')
+          ProxyPass         http://php:8000/ retry=0
+          ProxyPassReverse  http://php:8000/
+      </Location>
 
   __REDIRECT__
   __SSL__
@@ -104,10 +123,10 @@ features:
 
   deny: |
     # Deny Definition
-    <FilesMatch "__REGEX__">
+    <LocationMatch "__REGEX__">
         Order allow,deny
         Deny from all
-    </FilesMatch>
+    </LocationMatch>
 
   server_status: |
     # Status Page

--- a/cfg/vhost-gen/apache24.yml-example-vhost
+++ b/cfg/vhost-gen/apache24.yml-example-vhost
@@ -55,10 +55,10 @@ vhost: |
   __REDIRECT__
   __SSL__
   __VHOST_DOCROOT__
-  __VHOST_RPROXY__
   __PHP_FPM__
   __ALIASES__
   __DENIES__
+  __VHOST_RPROXY__
   __SERVER_STATUS__
       # Custom directives
   __CUSTOM__
@@ -86,13 +86,30 @@ vhost_type:
         Require all granted
     </Directory>
 
-  # Reverse Proxy (-r)
+  # Reverse Proxy (-r http(s)://ADDR:PORT)
   rproxy: |
-    # Define the vhost to reverse proxy
-    ProxyRequests On
+    # Define Reverse Proxy
+    ProxyRequests     Off
     ProxyPreserveHost On
-    ProxyPass __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT____LOCATION__
-    ProxyPassReverse __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT____LOCATION__
+    ProxyPass         __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
+    ProxyPassReverse  __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+
+  # Reverse Proxy with websocket support (-r ws(s)://ADDR:PORT)
+  rproxy_ws: |
+    # Define Reverse Proxy with Websock support
+    ProxyRequests Off
+    <location __LOCATION__>
+        # Websocket Rewrite Settings
+        RewriteEngine On
+        RewriteCond %{HTTP:Connection} Upgrade   [NC]
+        RewriteCond %{HTTP:Upgrade}    websocket [NC]
+        RewriteRule ^/?(.*)$ __WS_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/$1 [P,L]
+
+        # Reverse Proxy Settings
+        ProxyPreserveHost On
+        ProxyPass         __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
+        ProxyPassReverse  __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+    </location>
 
 
 ###
@@ -141,6 +158,7 @@ features:
     # Alias Definition
     Alias "__ALIAS__" "__PATH____ALIAS__"
     <Location "__ALIAS__">
+        ProxyPass !
     __XDOMAIN_REQ__
     </Location>
     <Directory "__PATH____ALIAS__">

--- a/cfg/vhost-gen/apache24.yml-example-vhost
+++ b/cfg/vhost-gen/apache24.yml-example-vhost
@@ -40,6 +40,17 @@
 #    __PHP_PORT__
 #
 
+###
+### Notes about Apache
+###
+
+#
+# 1. Each same directive is checked in order of definition (last one wins)
+# 2. Directives are ordered: Directory, DirectoryMatch, Files, and finally Location (last one wins)
+#   * Last match always takes precedence
+#
+# Exception: Directories, where shortest path is matched first
+# Exception: ProxyPass and Alias first match and then stops
 
 ###
 ### Basic vHost skeleton
@@ -55,10 +66,10 @@ vhost: |
   __REDIRECT__
   __SSL__
   __VHOST_DOCROOT__
+  __VHOST_RPROXY__
   __PHP_FPM__
   __ALIASES__
   __DENIES__
-  __VHOST_RPROXY__
   __SERVER_STATUS__
       # Custom directives
   __CUSTOM__
@@ -88,28 +99,40 @@ vhost_type:
 
   # Reverse Proxy (-r http(s)://ADDR:PORT)
   rproxy: |
-    # Define Reverse Proxy
+    # ProxyRequests:     Disable "Forward Proxy"
+    # ProxyPreserveHost: Pass "Host" header to remote
+    # ProxyAddHeaders:   Add "X-Forward-*" headers
+    # ProxyVia:          Add "Via" header
     ProxyRequests     Off
     ProxyPreserveHost On
-    ProxyPass         __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
-    ProxyPassReverse  __LOCATION__ __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+    ProxyAddHeaders   On
+    ProxyVia          On
+    <Location __LOCATION__>
+        # Reverse Proxy
+        ProxyPass         __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
+        ProxyPassReverse  __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
+    </Location>
 
   # Reverse Proxy with websocket support (-r ws(s)://ADDR:PORT)
   rproxy_ws: |
-    # Define Reverse Proxy with Websock support
-    ProxyRequests Off
-    <location __LOCATION__>
+    # ProxyRequests:     Disable "Forward Proxy"
+    # ProxyPreserveHost: Pass "Host" header to remote
+    # ProxyAddHeaders:   Add "X-Forward-*" headers
+    # ProxyVia:          Add "Via" header
+    ProxyRequests     Off
+    ProxyPreserveHost On
+    ProxyAddHeaders   On
+    ProxyVia          On
+    <Location __LOCATION__>
         # Websocket Rewrite Settings
         RewriteEngine On
         RewriteCond %{HTTP:Connection} Upgrade   [NC]
         RewriteCond %{HTTP:Upgrade}    websocket [NC]
         RewriteRule ^/?(.*)$ __WS_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/$1 [P,L]
-
-        # Reverse Proxy Settings
-        ProxyPreserveHost On
+        # Reverse Proxy
         ProxyPass         __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/ retry=0
         ProxyPassReverse  __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__/
-    </location>
+    </Location>
 
 
 ###
@@ -169,10 +192,10 @@ features:
 
   deny: |
     # Deny Definition
-    <FilesMatch "__REGEX__">
+    <LocationMatch "__REGEX__">
         Order allow,deny
         Deny from all
-    </FilesMatch>
+    </LocationMatch>
 
   server_status: |
     # Status Page

--- a/cfg/vhost-gen/nginx.yml-example-rproxy
+++ b/cfg/vhost-gen/nginx.yml-example-rproxy
@@ -48,8 +48,11 @@ vhost: |
 
       # Reverse Proxy definition (Ensure to adjust the port, currently '8000')
       location / {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        # https://stackoverflow.com/a/72586833
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Proxy connection
         proxy_pass http://php:8000;
       }
 

--- a/cfg/vhost-gen/nginx.yml-example-vhost
+++ b/cfg/vhost-gen/nginx.yml-example-vhost
@@ -75,12 +75,31 @@ vhost_type:
     root         "__DOCUMENT_ROOT__";
     index        __INDEX__;
 
-  # Reverse Proxy (-r)
+  # Reverse Proxy (-r http(s)://ADDR:PORT)
   rproxy: |
-    # Define the vhost to reverse proxy
+    # Define Reverse Proxy
     location __LOCATION__ {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        # https://stackoverflow.com/a/72586833
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Proxy connection
+        proxy_pass __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__;
+    }
+
+  # Reverse Proxy with websocket support (-r ws(s)://ADDR:PORT)
+  rproxy_ws: |
+    # Define Reverse Proxy with Websock support
+    location __LOCATION__ {
+        # https://stackoverflow.com/a/72586833
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Websocket settings
+        proxy_http_version          1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        # Proxy connection
         proxy_pass __PROXY_PROTO__://__PROXY_ADDR__:__PROXY_PORT__;
     }
 

--- a/compose/docker-compose.override.yml-php-multi.yml
+++ b/compose/docker-compose.override.yml-php-multi.yml
@@ -34,7 +34,7 @@ services:
 
   php54:
     <<: *default-php
-    image: devilbox/php-fpm:5.4-prod-release-0.148
+    image: devilbox/php-fpm:5.4-prod-0.148
     hostname: php54
     networks:
       app_net:
@@ -52,7 +52,7 @@ services:
 
   php55:
     <<: *default-php
-    image: devilbox/php-fpm:5.5-prod-release-0.148
+    image: devilbox/php-fpm:5.5-prod-0.148
     hostname: php55
     networks:
       app_net:
@@ -70,7 +70,7 @@ services:
 
   php56:
     <<: *default-php
-    image: devilbox/php-fpm:5.6-prod-release-0.148
+    image: devilbox/php-fpm:5.6-prod-0.148
     hostname: php56
     networks:
       app_net:
@@ -88,7 +88,7 @@ services:
 
   php70:
     <<: *default-php
-    image: devilbox/php-fpm:7.0-prod-release-0.148
+    image: devilbox/php-fpm:7.0-prod-0.148
     hostname: php70
     networks:
       app_net:
@@ -106,7 +106,7 @@ services:
 
   php71:
     <<: *default-php
-    image: devilbox/php-fpm:7.1-prod-release-0.148
+    image: devilbox/php-fpm:7.1-prod-0.148
     hostname: php71
     networks:
       app_net:
@@ -124,7 +124,7 @@ services:
 
   php72:
     <<: *default-php
-    image: devilbox/php-fpm:7.2-prod-release-0.148
+    image: devilbox/php-fpm:7.2-prod-0.148
     hostname: php72
     networks:
       app_net:
@@ -142,7 +142,7 @@ services:
 
   php73:
     <<: *default-php
-    image: devilbox/php-fpm:7.3-prod-release-0.148
+    image: devilbox/php-fpm:7.3-prod-0.148
     hostname: php73
     networks:
       app_net:
@@ -160,7 +160,7 @@ services:
 
   php74:
     <<: *default-php
-    image: devilbox/php-fpm:7.4-prod-release-0.148
+    image: devilbox/php-fpm:7.4-prod-0.148
     hostname: php74
     networks:
       app_net:
@@ -178,7 +178,7 @@ services:
 
   php80:
     <<: *default-php
-    image: devilbox/php-fpm:8.0-prod-release-0.148
+    image: devilbox/php-fpm:8.0-prod-0.148
     hostname: php80
     networks:
       app_net:
@@ -196,7 +196,7 @@ services:
 
   php81:
     <<: *default-php
-    image: devilbox/php-fpm:8.1-prod-release-0.148
+    image: devilbox/php-fpm:8.1-prod-0.148
     hostname: php81
     networks:
       app_net:
@@ -214,7 +214,7 @@ services:
 
   php82:
     <<: *default-php
-    image: devilbox/php-fpm:8.2-prod-release-0.148
+    image: devilbox/php-fpm:8.2-prod-0.148
     hostname: php82
     networks:
       app_net:

--- a/compose/docker-compose.override.yml-php-multi.yml
+++ b/compose/docker-compose.override.yml-php-multi.yml
@@ -34,7 +34,7 @@ services:
 
   php54:
     <<: *default-php
-    image: devilbox/php-fpm:5.4-prod-0.147
+    image: devilbox/php-fpm:5.4-prod-release-0.148
     hostname: php54
     networks:
       app_net:
@@ -43,16 +43,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-5.4:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-5.4:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-5.4:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-5.4:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php55:
     <<: *default-php
-    image: devilbox/php-fpm:5.5-prod-0.147
+    image: devilbox/php-fpm:5.5-prod-release-0.148
     hostname: php55
     networks:
       app_net:
@@ -61,16 +61,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-5.5:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-5.5:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-5.5:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-5.5:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php56:
     <<: *default-php
-    image: devilbox/php-fpm:5.6-prod-0.147
+    image: devilbox/php-fpm:5.6-prod-release-0.148
     hostname: php56
     networks:
       app_net:
@@ -79,16 +79,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-5.6:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-5.6:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-5.6:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-5.6:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php70:
     <<: *default-php
-    image: devilbox/php-fpm:7.0-prod-0.147
+    image: devilbox/php-fpm:7.0-prod-release-0.148
     hostname: php70
     networks:
       app_net:
@@ -97,16 +97,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-7.0:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-7.0:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-7.0:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-7.0:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php71:
     <<: *default-php
-    image: devilbox/php-fpm:7.1-prod-0.147
+    image: devilbox/php-fpm:7.1-prod-release-0.148
     hostname: php71
     networks:
       app_net:
@@ -115,16 +115,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-7.1:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-7.1:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-7.1:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-7.1:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php72:
     <<: *default-php
-    image: devilbox/php-fpm:7.2-prod-0.147
+    image: devilbox/php-fpm:7.2-prod-release-0.148
     hostname: php72
     networks:
       app_net:
@@ -133,16 +133,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-7.2:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-7.2:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-7.2:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-7.2:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php73:
     <<: *default-php
-    image: devilbox/php-fpm:7.3-prod-0.147
+    image: devilbox/php-fpm:7.3-prod-release-0.148
     hostname: php73
     networks:
       app_net:
@@ -151,16 +151,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-7.3:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-7.3:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-7.3:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-7.3:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php74:
     <<: *default-php
-    image: devilbox/php-fpm:7.4-prod-0.147
+    image: devilbox/php-fpm:7.4-prod-release-0.148
     hostname: php74
     networks:
       app_net:
@@ -169,16 +169,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-7.4:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-7.4:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-7.4:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-7.4:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php80:
     <<: *default-php
-    image: devilbox/php-fpm:8.0-prod-0.147
+    image: devilbox/php-fpm:8.0-prod-release-0.148
     hostname: php80
     networks:
       app_net:
@@ -187,16 +187,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-8.0:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-8.0:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-8.0:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-8.0:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php81:
     <<: *default-php
-    image: devilbox/php-fpm:8.1-prod-0.147
+    image: devilbox/php-fpm:8.1-prod-release-0.148
     hostname: php81
     networks:
       app_net:
@@ -205,16 +205,16 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-8.1:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-8.1:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-8.1:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-8.1:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
   php82:
     <<: *default-php
-    image: devilbox/php-fpm:8.2-prod-0.147
+    image: devilbox/php-fpm:8.2-prod-release-0.148
     hostname: php82
     networks:
       app_net:
@@ -223,9 +223,9 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-8.2:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-8.2:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/cfg/php-startup-8.2:/startup.1.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/cfg/php-startup-8.2:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
-      - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
+      # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,7 +227,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:${HTTPD_FLAVOUR:-alpine}-release-1.0-beta2
+    image: devilbox/${HTTPD_SERVER}:${HTTPD_FLAVOUR:-alpine}-1.0-beta2
     hostname: httpd
 
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-0.147
+    image: devilbox/php-fpm:${PHP_SERVER}-work-release-0.148
     hostname: php
 
     ##
@@ -227,7 +227,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:${HTTPD_FLAVOUR:-alpine}-1.0-beta1
+    image: devilbox/${HTTPD_SERVER}:${HTTPD_FLAVOUR:-alpine}-release-1.0-beta2
     hostname: httpd
 
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-release-0.148
+    image: devilbox/php-fpm:${PHP_SERVER}-work-0.148
     hostname: php
 
     ##


### PR DESCRIPTION
## Release v3.0.0-beta-0.2 (2022-12-27)

The Backend configuration now supports websockets as well:

Please report issues in **this PR** or reach out in **[Discord](https://discord.gg/2wP3V6kBj4)**.

![Screenshot 2022-12-26 14-28-34  selection](https://user-images.githubusercontent.com/12533999/209555838-927886fd-3cab-4a8b-b4e0-b0c8003eef6a.png)



file: `/shared/httpd/<project>/.devilbox/backend.cfg`
```bash
# PHP-FPM backend
conf:phpfpm:tcp:php80:9000

# HTTP Reverse Proxy backend
conf:rproxy:http:172.16.238.10:3000

# HTTPS Reverse Proxy backend
conf:rproxy:https:172.16.238.10:3000

# Websocket Reverse Proxy backend
conf:rproxy:ws:172.16.238.10:3000

# SSL Websocket Reverse Proxy backend
conf:rproxy:wss:172.16.238.10:3000
```

Once you're done with `backend.cfg` changes, head over to the Intranet C&C page (http://localhost/cnc.php) and Reload `watcherd`.


### Fixed
- Intranet: vhost overview: allow HTTP 426 to succeed in vhost page (websocket projects)
- Intranet: vhost overview: Reverse Proxy or Websocket backends do not require a `htdocs/` dir for healthcheck
- Fixed reverse proxy template generation for Apache 2.2 and Apache 2.4 [vhost-gen #51](https://github.com/devilbox/vhost-gen/pull/51)
- Fixed Nginx hash bucket size length to allow long hostnames

### Added
- Reverse Proxy automation for websocket projects (`ws://<host>:<port>` or `wss:<host>:<port>`) (Does not work with Apache 2.2)
- Added tool `wscat` to be able to test websocket connections
- Intranet: vhost overview now also shows websocket projects

### Changed
- Do not mount any startup/autostart script directories for multi-php compose as they do not contain tools

## Affected Issues / PR's

* Refs: #797
* Refs: #782
