### PR TITLE
shell.bat: Support multiple PHP container

### DIFF
--- a/shell.bat
+++ b/shell.bat
@@ -1,3 +1,5 @@
+@echo off
+
 set php=php
 
 if not "%~1"=="" (

--- a/shell.bat
+++ b/shell.bat
@@ -1,2 +1,7 @@
+set php=php
 
-docker-compose exec --user devilbox php  /bin/sh -c "cd /shared/httpd; exec bash -l"
+if not "%~1"=="" (
+    set php=%1
+)
+
+docker-compose exec --user devilbox %php% /bin/sh -c "cd /shared/httpd; exec bash -l"


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# shell.bat: Support multiple PHP container

### Goal
<!-- What is the goal of this Pull request -->
<!-- What do you want to achieve? -->
With this update, you can use `shell.bat` to go into the default PHP container or provide an argument to specify a particular PHP container to use. For example, to use the PHP 8.2 container, you can run `shell.bat php82`.


### DESCRIPTION

<!-- Enter a short description here -->
<!-- Link to issues in case it fixes an issue -->

