### PR TITLE
fix: Allow commenting out backend.cfg

### DIFF
--- a/.devilbox/www/include/lib/container/Httpd.php
+++ b/.devilbox/www/include/lib/container/Httpd.php
@@ -217,6 +217,10 @@ class Httpd extends BaseClass implements BaseInterface
 		$cont = stream_get_contents($fp);
 		fclose($fp);
 
+		$semicolon_pos = strpos($cont, ';');
+		if($semicolon_pos !== false && $semicolon_pos == 0) {
+				return 'default';
+		}
 		// conf:<type>:<proto>:<server>:<port>
 		$arr = explode(':', $cont);
 


### PR DESCRIPTION
Regarding issue [#950](https://github.com/cytopia/devilbox/issues/950)

Did not see any processing regarding if the option is commented out or not. Now we check if the first symbol is a semicolon (;) and in case it is, we return `default` rather than the commented out option.

I did test this locally, and it seems the issue was purely visual.
When the semicolon (;) is present, we can see a message like this
```[WARN] [second.loc] Backend rewrite config is invalid: Invalid backend string ';conf:phpfpm:tcp:php81:9000'. It must start with 'conf:'```
In the `Command & Control` tab which stops the app from using the commented out backend and uses the default one.
