### PR TITLE
Add port forwarding in a multi-PHP environment

### DIFF
--- a/compose/docker-compose.override.yml-php-multi.yml
+++ b/compose/docker-compose.override.yml-php-multi.yml
@@ -21,6 +21,8 @@ x-app: &default-php
     - DISABLE_MODULES=${PHP_MODULES_DISABLE}
     # Mail-catching
     - ENABLE_MAIL=${PHP_MAIL_CATCH_ALL:-2}
+    ## Enable 127.0.0.1 Port-forwarding
+    - FORWARD_PORTS_TO_LOCALHOST=80:httpd:80,443:httpd:443,3306:mysql:3306,5432:pgsql:5432,6379:redis:6379,11211:memcd:11211,27017:mongo:27017
   dns:
     - 172.16.238.100
   depends_on:


### PR DESCRIPTION
if i set a custom php backend for a project i can't connect to mysql throught host 127.0.0.1
