### PR TITLE
Fix typo _connect_erro

### DIFF
--- a/.devilbox/www/include/lib/container/BaseClass.php
+++ b/.devilbox/www/include/lib/container/BaseClass.php
@@ -181,7 +181,7 @@ class BaseClass
 	 */
 	public function setConnectErrno($errno)
 	{
-		$this->_connect_erro = $errno;
+		$this->_connect_errno = $errno;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Add a name to your PR below -->
# Fix typo in _connect_erro

### Goal
The PR is intended to prevent PHP8.2 deprecation warning that happens because of the _connect_erro <-> _connect_errno typo.

### DESCRIPTION
Correct _connect_erro to _connect_errno in order to prevent PHP8.2 deprecation warning for creating dynamic properties.

The issue is mentioned here: https://github.com/cytopia/devilbox/issues/1018#issuecomment-2036566688

